### PR TITLE
docs: outline ConversationOrchestrator refactor plan

### DIFF
--- a/docs/conversation-orchestrator-refactor.md
+++ b/docs/conversation-orchestrator-refactor.md
@@ -1,0 +1,49 @@
+# ConversationOrchestrator refactor proposal
+
+## Pain points observed
+
+- `ConversationOrchestrator.ts` currently mixes imports from adapters, caching, heuristics, prompt construction, analytics and delivery inside a single function, which makes the file sprawl to ~650 lines and multiple responsibilities. 【F:server/services/ConversationOrchestrator.ts†L1-L657】
+- The `getEcoResponse` flow alone contains routing, greeting handling, asynchronous fetches, prompt building, LLM invocation, response shaping, side-effects (memory persistence, analytics) and fallback logic in-line. 【F:server/services/ConversationOrchestrator.ts†L278-L654】
+- Helper utilities such as `operacoesParalelas`, `fastLaneLLM`, and `montarContextoOtimizado` are embedded in the same module even though they could be reused/tested independently. 【F:server/services/ConversationOrchestrator.ts†L92-L266】
+
+## Suggested modular split
+
+1. **Entry-point orchestrator**
+   - Keep a lean `getEcoResponse` that orchestrates high-level steps by composing collaborators.
+   - Extract external dependencies behind interfaces (e.g. `ClaudeClient`, `SupabaseClient`, `ContextBuilderService`) that can be injected.
+
+2. **Greeting and micro-response pipeline**
+   - Move greeting detection (`respostaSaudacaoAutomatica`, `GreetGuard`, redundant greeting stripping) into `services/conversation/greeting.ts` to encapsulate the conditions and allow unit tests for first-response handling. 【F:server/services/ConversationOrchestrator.ts†L308-L353】【F:server/services/ConversationOrchestrator.ts†L424-L437】
+
+3. **Routing & heuristics module**
+   - Create a `ConversationRouter` responsible for `isLowComplexity`, `heuristicaPreViva`, and deciding between fast-lane and full flow. This router can expose `route(messages, flags): "fast" | "full"` and be unit-tested with crafted message fixtures. 【F:server/services/ConversationOrchestrator.ts†L77-L217】【F:server/services/ConversationOrchestrator.ts†L358-L440】
+
+4. **Parallel fetch service**
+   - Extract `operacoesParalelas` and `withTimeoutOrNull` into `services/conversation/parallelFetch.ts` so the orchestrator merely invokes `await parallelFetch.run(params)`. Provide dependency injection for embedding lookup, heuristics service, and memory search to make mocks trivial. 【F:server/services/ConversationOrchestrator.ts†L92-L155】【F:server/services/ConversationOrchestrator.ts†L444-L517】
+
+5. **Context assembly module**
+   - Wrap `montarContextoOtimizado` logic in a `ContextCache` class that receives `PROMPT_CACHE` and `ContextBuilder`. This class could also compute the cache key and log timings, keeping orchestration logic focused on control flow. 【F:server/services/ConversationOrchestrator.ts†L158-L197】
+
+6. **Response formatting & persistence**
+   - Consolidate the repeated block that cleans/strips greetings, enriches with bloco técnico, triggers async persistence, and tracks analytics into a `ResponseFinalizer`. It can expose `finalize({ rawResponse, bloco, metadata })` and be reused by both fast and full routes. 【F:server/services/ConversationOrchestrator.ts†L262-L438】【F:server/services/ConversationOrchestrator.ts†L563-L654】
+
+7. **Configuration & feature flags**
+   - Group the various env-driven constants (`ECO_*`) into a config module so tests can override them via dependency injection instead of process-level state.
+
+## Testing strategy
+
+- **Pure helpers**: add Jest unit tests for `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, and `heuristicaPreViva` with edge-case fixtures to lock behavior before refactoring. 【F:server/services/ConversationOrchestrator.ts†L53-L217】
+- **Router tests**: once routing logic is extracted, cover scenarios for fast-lane vs full, greeting suppression, and forced overrides using synthetic message arrays.
+- **Parallel fetch service**: inject fakes for embedding, heuristics, memories, and verify timeouts/fallbacks without hitting Supabase.
+- **Context cache**: test cache hit/miss behavior by stubbing `ContextBuilder.build` and asserting caching rules when `memoriasSemelhantes` exist.
+- **LLM clients**: wrap `claudeChatCompletion` behind an interface so tests can supply deterministic responses and exercise formatting/fallback paths for both fast and full pipelines.
+- **Integration slice tests**: create high-level tests that feed prepared messages into the orchestrator with stubbed dependencies to ensure analytics/memory side-effects are invoked (or skipped) as expected.
+
+## Isolation techniques
+
+- Introduce a `ConversationDependencies` object that is passed into the orchestrator, bundling external services. This makes it easy to stub them in tests.
+- Encapsulate background async fire-and-forget tasks (memory saving, analytics) inside a `PostProcessor` abstraction; in tests, expose hooks to await completion.
+- Normalize data structures into typed value objects (e.g. `ConversationContext`, `UserSignals`) to avoid loose `any` usage and simplify validation.
+- Consider moving feature toggles (e.g. greeting enablement) into a dedicated `FeatureFlags` service that can be toggled per test without mutating `process.env` globally.
+
+Implementing these steps incrementally—starting with extracting pure helpers and response finalization—will reduce the risk of regressions while making the codebase more testable and maintainable.

--- a/docs/conversation-orchestrator-refactor.md
+++ b/docs/conversation-orchestrator-refactor.md
@@ -47,3 +47,23 @@
 - Consider moving feature toggles (e.g. greeting enablement) into a dedicated `FeatureFlags` service that can be toggled per test without mutating `process.env` globally.
 
 Implementing these steps incrementally—starting with extracting pure helpers and response finalization—will reduce the risk of regressions while making the codebase more testable and maintainable.
+
+## Suggested implementation roadmap
+
+| Iteration | Focus area | Deliverables | Notes |
+|-----------|------------|--------------|-------|
+| 1 | Extract pure utilities | Move `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, `heuristicaPreViva` into dedicated modules with unit tests. 【F:server/services/ConversationOrchestrator.ts†L53-L217】 | Enables snapshotting current behavior before heavier refactors. |
+| 2 | Response finalizer | Implement `ResponseFinalizer` abstraction and update orchestrator to consume it. 【F:server/services/ConversationOrchestrator.ts†L262-L654】 | Centralizes cleanup, analytics hooks, and persistence triggers. |
+| 3 | Greeting pipeline | Introduce `greeting.ts` service and route first-message logic through it. 【F:server/services/ConversationOrchestrator.ts†L308-L437】 | Unlocks independent testing of salutation handling. |
+| 4 | Router module | Create `ConversationRouter` with fast/full decision logic and accompanying tests. 【F:server/services/ConversationOrchestrator.ts†L77-L440】 | Keeps complexity heuristics separated from orchestration. |
+| 5 | Parallel fetch service | Extract `operacoesParalelas` into `parallelFetch.ts` and wire via dependency injection. 【F:server/services/ConversationOrchestrator.ts†L92-L517】 | Simplifies async control flow and facilitates timeout simulations. |
+| 6 | Context cache service | Replace inline cache usage with `ContextCache` class and add coverage. 【F:server/services/ConversationOrchestrator.ts†L158-L197】 | Encapsulates cache key construction and logging. |
+| 7 | Dependency bundle & feature flags | Introduce `ConversationDependencies` and `FeatureFlags` modules. | Finalize seam creation for future changes and environment-specific toggles. |
+
+## Tracking refactor progress
+
+- Create a short-lived branch per iteration to keep pull requests reviewable.
+- For each extracted module, publish a README or JSDoc comment describing its contract and collaborators.
+- Maintain a checklist in the main refactor ticket mirroring the roadmap table above; mark tasks complete as modules migrate.
+- After iterations 3 and 4, run an integration smoke test (staging conversation) to ensure routing/greeting behavior remains intact.
+- Schedule a pairing or review session after iteration 5 to validate that parallel fetch error handling still meets product requirements.

--- a/server/services/ConversationOrchestrator.ts
+++ b/server/services/ConversationOrchestrator.ts
@@ -1,220 +1,32 @@
 // server/services/ConversationOrchestrator.ts
 import {
   ensureEnvs,
-  formatarTextoEco,
-  limparResposta,
   mapRoleForOpenAI,
   now,
   sleep,
   type GetEcoParams,
   type GetEcoResult,
-  type ParalelasResult,
 } from "../utils";
-
 import { supabaseWithBearer } from "../adapters/SupabaseAdapter";
-import { PROMPT_CACHE } from "../services/CacheService";
-import { getEmbeddingCached } from "../adapters/EmbeddingAdapter";
-import { gerarBlocoTecnicoComCache } from "../core/EmotionalAnalyzer";
 import { microReflexoLocal } from "../core/ResponseGenerator";
 import { claudeChatCompletion } from "../core/ClaudeAdapter";
-import { GreetGuard } from "../core/policies/GreetGuard";
 import { getDerivados, insightAbertura } from "../services/derivadosService";
-import { buscarHeuristicasSemelhantes } from "../services/heuristicaService";
-import { buscarMemoriasSemelhantes } from "../services/buscarMemorias";
-
-// 👉 usa o builder exportado pelo barrel services/promptContext/index.ts
-import { ContextBuilder } from "../services/promptContext";
-
-import {
-  respostaSaudacaoAutomatica,
-  type Msg as SaudMsg,
-} from "../utils/respostaSaudacaoAutomatica";
-import { saveMemoryOrReference } from "../services/MemoryService";
-import {
-  trackMensagemEnviada,
-  trackEcoDemorou,
-} from "../analytics/events/mixpanelEvents";
-
-// 🔽 logger
 import { log, isDebug } from "../services/promptContext/logger";
-// 🔽 helpers para cache key previsível
+
+import { defaultGreetingPipeline } from "./conversation/greeting";
+import { defaultConversationRouter } from "./conversation/router";
 import {
-  derivarNivel,
-  detectarSaudacaoBreve,
-} from "../services/promptContext/Selector";
+  defaultParallelFetchService,
+  withTimeoutOrNull,
+} from "./conversation/parallelFetch";
+import { defaultContextCache } from "./conversation/contextCache";
+import { defaultResponseFinalizer } from "./conversation/responseFinalizer";
+import { firstName } from "./conversation/helpers";
 
 /* ---------------------------- Consts ---------------------------- */
 
 const DERIVADOS_TIMEOUT_MS = Number(process.env.ECO_DERIVADOS_TIMEOUT_MS ?? 600);
 const PARALELAS_TIMEOUT_MS = Number(process.env.ECO_PARALELAS_TIMEOUT_MS ?? 180);
-
-/* ---------------------------- Helpers ---------------------------- */
-
-const firstName = (s?: string) => (s || "").trim().split(/\s+/)[0] || "";
-
-// Remove respostas do tipo “sou a Eco, não o {nome}”
-function stripIdentityCorrection(text: string, nome?: string) {
-  if (!nome) return text;
-  const re = new RegExp(
-    String.raw`(?:^|\n).*?(?:eu\s*)?sou\s*a?\s*eco[^.\n]*não\s+o?a?\s*${nome}\b.*`,
-    "i"
-  );
-  return text.replace(re, "").trim();
-}
-
-/** Remove “Oi/Olá/Bom dia…” redundante quando não é a 1ª resposta da Eco */
-function stripRedundantGreeting(text: string, hasAssistantBefore: boolean) {
-  if (!hasAssistantBefore) return text;
-  let out = text.replace(
-    /^\s*(?:oi|olá|ola|bom dia|boa tarde|boa noite)[,!\.\-\–—\s]+/i,
-    ""
-  );
-  // se sobrar vazio, volta original
-  out = out.trim();
-  return out.length ? out : text;
-}
-
-function isLowComplexity(texto: string) {
-  const t = (texto || "").trim();
-  if (t.length <= 140) return true;
-  const words = t.split(/\s+/).length;
-  if (words <= 22) return true;
-  return !/crise|p[aâ]nico|desesper|vontade de sumir|explod|insuport|plano detalhado|passo a passo/i.test(
-    t
-  );
-}
-
-/** ⬇️ tipo auxiliar: paralelas + memórias */
-type ParalelasResultPlus = ParalelasResult & {
-  memsSemelhantes: any[];
-};
-
-async function operacoesParalelas(
-  ultimaMsg: string,
-  userId?: string,
-  supabase?: any
-): Promise<ParalelasResultPlus> {
-  let userEmbedding: number[] = [];
-  if (ultimaMsg.trim().length > 0) {
-    userEmbedding = await getEmbeddingCached(ultimaMsg, "entrada_usuario");
-  }
-
-  let heuristicas: any[] = [];
-  let memsSemelhantes: any[] = [];
-
-  if (userEmbedding.length > 0) {
-    try {
-      heuristicas = await buscarHeuristicasSemelhantes({
-        usuarioId: userId ?? null,
-        userEmbedding,
-        matchCount: 5,
-      });
-    } catch {
-      heuristicas = [];
-    }
-
-    // 🔎 busca memórias similares (semânticas)
-    if (userId) {
-      try {
-        // se o serviço aceitar injeção do client, passamos; senão, ele ignora
-        memsSemelhantes = await buscarMemoriasSemelhantes(userId, {
-          texto: ultimaMsg,
-          k: 3,
-          threshold: 0.12,
-          supabaseClient: supabase,
-        });
-      } catch (e: any) {
-        if (isDebug())
-          log.warn(
-            `[operacoesParalelas] buscarMemoriasSemelhantes falhou: ${e?.message}`
-          );
-        memsSemelhantes = [];
-      }
-    }
-  }
-
-  return { heuristicas, userEmbedding, memsSemelhantes };
-}
-
-// Timeout que NÃO quebra o fluxo (retorna null em erro/timeout)
-async function withTimeoutOrNull<T>(
-  p: Promise<T>,
-  ms: number,
-  label = "tarefa"
-): Promise<T | null> {
-  try {
-    return (await Promise.race([
-      p,
-      new Promise<T>((_, rej) =>
-        setTimeout(() => rej(new Error(`${label} timeout ${ms}ms`)), ms)
-      ),
-    ])) as T;
-  } catch (e: any) {
-    log.warn(`[Orchestrator] ${label} falhou/timeout (${ms}ms): ${e?.message}`);
-    return null;
-  }
-}
-
-/**
- * ⚙️ Monta (ou recupera) o contexto com cache por (userId, nível, intensidade).
- * Observação: o ContextBuilder já inclui "Mensagem atual: ..." no prompt final.
- * Portanto, não concatenamos novamente ao ler do cache.
- */
-async function montarContextoOtimizado(params: any) {
-  const entrada = String(params.texto ?? "");
-  const saudacaoBreve = detectarSaudacaoBreve(entrada);
-  const nivel = derivarNivel(entrada, saudacaoBreve);
-  const intensidade = Math.max(
-    0,
-    ...(params.mems ?? []).map((m: any) => Number(m?.intensidade ?? 0))
-  );
-
-  // ✅ considerar memórias semelhantes e evitar cache quando existirem
-  const msCount = Array.isArray(params.memoriasSemelhantes)
-    ? params.memoriasSemelhantes.length
-    : 0;
-
-  const cacheKey = `ctx:${params.userId || "anon"}:${nivel}:${Math.round(
-    intensidade
-  )}:ms${msCount}`;
-
-  const cached = PROMPT_CACHE.get(cacheKey);
-  if (cached && msCount === 0) {
-    if (isDebug()) log.debug("[Orchestrator] contexto via cache", { cacheKey });
-    return cached; // ✅ já inclui "Mensagem atual: ..."
-  }
-
-  const t0 = Date.now();
-  const contexto = await ContextBuilder.build(params); // ✅ usa builder unificado
-  if (isDebug())
-    log.debug("[Orchestrator] contexto construído", { ms: Date.now() - t0 });
-
-  // NV1 tende a se repetir mais — cache curto ajuda (apenas quando msCount==0)
-  if (nivel <= 2 && msCount === 0) PROMPT_CACHE.set(cacheKey, contexto);
-
-  return contexto;
-}
-
-function heuristicaPreViva(m: string) {
-  const texto = (m || "").toLowerCase();
-  const len = texto.length;
-  const gat = [
-    /ang[uú]st/i,
-    /p[aâ]nico/i,
-    /desesper/i,
-    /crise/i,
-    /sofr/i,
-    /n[aã]o aguento/i,
-    /vontade de sumir/i,
-    /explod/i,
-    /impulsiv/i,
-    /medo/i,
-    /ansiedad/i,
-    /culpa/i,
-    /triste/i,
-  ];
-  return gat.some((r) => r.test(texto)) || len >= 180;
-}
 
 /* -------------------------- Fast-lane --------------------------- */
 
@@ -256,24 +68,14 @@ async function fastLaneLLM({
   } catch (e: any) {
     log.warn(`[fastLaneLLM] falhou: ${e?.message}`);
     const fallback = "Tô aqui com você. Quer me contar um pouco mais?";
-    return { cleaned: fallback, usage: undefined, model: "fastlane-fallback" };
+    return { raw: fallback, usage: undefined, model: "fastlane-fallback" };
   }
 
   const raw: string = data?.content ?? "";
-  let cleaned = formatarTextoEco(limparResposta(raw || "Posso te ajudar nisso!"));
-  cleaned = stripIdentityCorrection(cleaned, nome);
-  return { cleaned, usage: data?.usage, model: data?.model };
+  return { raw, usage: data?.usage, model: data?.model };
 }
 
 /* -------------------------- Orquestrador ------------------------ */
-
-type SaudRole = "user" | "assistant" | "system";
-function toSaudRole(r: any): SaudRole | undefined {
-  if (r === "user" || r === "assistant" || r === "system") return r;
-  const m = mapRoleForOpenAI(r);
-  if (m === "user" || m === "assistant" || m === "system") return m;
-  return undefined;
-}
 
 export async function getEcoResponse(
   {
@@ -285,169 +87,81 @@ export async function getEcoResponse(
     forcarMetodoViva = false,
     blocoTecnicoForcado = null,
     clientHour,
-    // ⬇️ novos
     promptOverride,
     metaFromBuilder,
   }: GetEcoParams & { promptOverride?: string; metaFromBuilder?: any }
 ): Promise<GetEcoResult> {
-  const t0 = now();
   ensureEnvs();
 
   if (!Array.isArray(messages) || messages.length === 0) {
     throw new Error('Parâmetro "messages" vazio ou inválido.');
   }
-  const ultimaMsg = (messages as any).at(-1)?.content || "";
 
-  // client supabase o quanto antes (para paralelas)
+  const ultimaMsg = (messages as any).at(-1)?.content || "";
   const supabase = supabaseWithBearer(accessToken);
 
-  // 0) micro-reflexo local
   const micro = microReflexoLocal(ultimaMsg);
-  if (micro) return { message: micro };
-
-  // 1) saudação/despedida — **versão robusta**
-  // ------------------------------------------------------------
-  // Dispara somente se: thread ainda não tem resposta da Eco
-  // e a última msg do usuário é uma saudação curta (ou está vazia)
-  // e não há conteúdo substantivo.
-  const greetingEnabled = process.env.ECO_GREETING_BACKEND_ENABLED !== "0";
-  if (greetingEnabled) {
-    const assistantCount = (messages as any[]).filter(
-      (m) => mapRoleForOpenAI((m as any).role) === "assistant"
-    ).length;
-    const threadVazia = assistantCount === 0;
-
-    const ultima = (ultimaMsg || "").trim();
-    const saudacaoCurta = /^\s*(oi|olá|ola|bom dia|boa tarde|boa noite)\s*[!.?]*$/i.test(
-      ultima
-    );
-    const conteudoSubstantivo =
-      /[?]|(\b(quero|preciso|como|por que|porque|ajuda|planejar|plano|passo|sinto|penso|lembro)\b)/i.test(
-        ultima
-      ) || ultima.split(/\s+/).length > 6;
-
-    const saudaMsgs: SaudMsg[] = [];
-    for (const m of (messages as any[]).slice(-4)) {
-      saudaMsgs.push({
-        role: toSaudRole((m as any).role),
-        content: (m as any).content || "",
-      });
-    }
-    const auto = respostaSaudacaoAutomatica({
-      messages: saudaMsgs,
-      userName,
-      clientHour,
-    });
-
-    if (auto?.meta?.isFarewell) return { message: auto.text };
-
-    if (
-      auto?.meta?.isGreeting &&
-      threadVazia &&
-      (saudacaoCurta || ultima.length === 0) &&
-      !conteudoSubstantivo &&
-      GreetGuard.can(userId)
-    ) {
-      GreetGuard.mark(userId);
-      return { message: auto.text };
-    }
-    // caso contrário, suprime saudação
+  if (micro) {
+    return { message: micro };
   }
-  // ------------------------------------------------------------
 
-  // 2) roteamento
-  const saudacaoBreve = detectarSaudacaoBreve(ultimaMsg);
-  const nivelRoteador = derivarNivel(ultimaMsg, saudacaoBreve);
-  const low = isLowComplexity(ultimaMsg);
-  const vivaAtivo = forcarMetodoViva || heuristicaPreViva(ultimaMsg);
+  const greetingResult = defaultGreetingPipeline.handle({
+    messages: messages as any,
+    ultimaMsg,
+    userId,
+    userName,
+    clientHour,
+    greetingEnabled: process.env.ECO_GREETING_BACKEND_ENABLED !== "0",
+  });
 
-  // 🔁 IMPORTANTE: fast-lane reativada por padrão
-  // -> Só força rota completa se houver promptOverride "de verdade".
-  const forceFull =
-    typeof promptOverride === "string" && promptOverride.trim().length > 0;
+  if (greetingResult.handled && greetingResult.response) {
+    return { message: greetingResult.response };
+  }
 
-  if (isDebug())
+  const decision = defaultConversationRouter.decide({
+    messages: messages as any,
+    ultimaMsg,
+    forcarMetodoViva,
+    promptOverride,
+  });
+
+  if (isDebug()) {
     log.debug("[Orchestrator] flags", {
-      hasPromptOverride: typeof promptOverride,
       promptOverrideLen: (promptOverride || "").trim().length,
-      low,
-      vivaAtivo,
-      nivelRoteador,
+      low: decision.lowComplexity,
+      vivaAtivo: decision.vivaAtivo,
+      nivelRoteador: decision.nivelRoteador,
       ultimaLen: (ultimaMsg || "").length,
+      mode: decision.mode,
     });
+  }
 
-  const podeFastLane =
-    !forceFull &&
-    low &&
-    !vivaAtivo &&
-    (typeof nivelRoteador === "number" ? nivelRoteador <= 1 : true);
-
-  // contabiliza se já houve mensagem da Eco antes (para anti-saudação)
-  const hasAssistantBefore =
-    (messages as any[]).filter(
-      (m) => mapRoleForOpenAI((m as any).role) === "assistant"
-    ).length > 0;
-
-  if (podeFastLane) {
+  if (decision.mode === "fast") {
     const inicioFast = now();
     const fast = await fastLaneLLM({ messages: messages as any, userName });
 
-    let bloco: any = null;
-    try {
-      bloco = await gerarBlocoTecnicoComCache(ultimaMsg, fast.cleaned);
-    } catch {}
-
-    (async () => {
-      try {
-        if (userId) {
-          await saveMemoryOrReference({
-            supabase,
-            userId,
-            lastMessageId: (messages as any).at(-1)?.id ?? undefined,
-            cleaned: fast.cleaned,
-            bloco,
-            ultimaMsg,
-          });
-        }
-      } catch (e) {
-        log.warn("⚠️ Pós-processo fastLane falhou:", (e as Error).message);
-      }
-    })();
-
-    trackMensagemEnviada({
+    return defaultResponseFinalizer.finalize({
+      raw: fast.raw,
+      ultimaMsg,
+      userName,
+      hasAssistantBefore: decision.hasAssistantBefore,
       userId,
-      tempoRespostaMs: now() - inicioFast,
-      tokensUsados: fast?.usage?.total_tokens ?? undefined,
+      supabase,
+      lastMessageId: (messages as any).at(-1)?.id ?? undefined,
+      mode: "fast",
+      startedAt: inicioFast,
+      usageTokens: fast?.usage?.total_tokens ?? undefined,
       modelo: fast?.model,
     });
-
-    let msgFinal = fast.cleaned;
-    msgFinal = stripRedundantGreeting(msgFinal, hasAssistantBefore);
-
-    const resp: GetEcoResult = { message: msgFinal };
-    if (bloco && typeof bloco.intensidade === "number") {
-      resp.intensidade = bloco.intensidade;
-      resp.resumo = bloco?.analise_resumo?.trim().length
-        ? bloco.analise_resumo.trim()
-        : msgFinal;
-      resp.emocao = bloco.emocao_principal || "indefinida";
-      resp.tags = Array.isArray(bloco.tags) ? bloco.tags : [];
-      resp.categoria = bloco.categoria ?? null;
-    } else if (bloco) {
-      resp.categoria = bloco.categoria ?? null;
-    }
-    return resp;
   }
 
-  // 3) rota completa
-
-  // 3.1) paralelas — só se NÃO houver promptOverride
   let heuristicas: any[] = [];
   let userEmbedding: number[] = [];
   let memsSemelhantes: any[] = [];
+
   if (!promptOverride) {
     const paralelas = await Promise.race([
-      operacoesParalelas(ultimaMsg, userId, supabase),
+      defaultParallelFetchService.run({ ultimaMsg, userId, supabase }),
       sleep(PARALELAS_TIMEOUT_MS).then(() => ({
         heuristicas: [],
         userEmbedding: [],
@@ -456,10 +170,9 @@ export async function getEcoResponse(
     ]);
     heuristicas = paralelas.heuristicas;
     userEmbedding = paralelas.userEmbedding;
-    memsSemelhantes = (paralelas as any).memsSemelhantes ?? [];
+    memsSemelhantes = paralelas.memsSemelhantes ?? [];
   }
 
-  // 3.2) derivados — tolerante a timeout/erro; pula se promptOverride ou NV1
   const shouldSkipDerivados =
     !!promptOverride ||
     (metaFromBuilder && Number(metaFromBuilder.nivel) === 1) ||
@@ -512,7 +225,8 @@ export async function getEcoResponse(
           }
         })(),
         DERIVADOS_TIMEOUT_MS,
-        "derivados"
+        "derivados",
+        { logger: log }
       );
 
   const aberturaHibrida = derivados
@@ -525,17 +239,15 @@ export async function getEcoResponse(
       })()
     : null;
 
-  // 3.3) system prompt (usa override se veio da rota)
   const systemPrompt =
     promptOverride ??
-    (await montarContextoOtimizado({
+    (await defaultContextCache.build({
       userId,
       userName,
       perfil: null,
       mems,
-      // ✅ nome padronizado que o ContextBuilder entende:
       memoriasSemelhantes: memsSemelhantes,
-      forcarMetodoViva: vivaAtivo,
+      forcarMetodoViva: decision.vivaAtivo,
       blocoTecnicoForcado,
       texto: ultimaMsg,
       heuristicas,
@@ -572,86 +284,42 @@ export async function getEcoResponse(
     log.warn(`[getEcoResponse] LLM rota completa falhou: ${e?.message}`);
     const msg =
       "Desculpa, tive um problema técnico agora. Topa tentar de novo?";
-    const cleaned = stripIdentityCorrection(
-      formatarTextoEco(limparResposta(msg)),
-      firstName(userName)
-    );
-    const duracaoEcoErr = now() - inicioEco;
-    if (duracaoEcoErr > 2500)
-      trackEcoDemorou({ userId, duracaoMs: duracaoEcoErr, ultimaMsg });
-    trackMensagemEnviada({
+    return defaultResponseFinalizer.finalize({
+      raw: msg,
+      ultimaMsg,
+      userName,
+      hasAssistantBefore: decision.hasAssistantBefore,
       userId,
-      tempoRespostaMs: duracaoEcoErr,
-      tokensUsados: undefined,
+      supabase,
+      lastMessageId: (messages as any).at(-1)?.id ?? undefined,
+      mode: "full",
+      startedAt: inicioEco,
+      usageTokens: undefined,
       modelo: "full-fallback",
+      skipBloco: true,
     });
-    return { message: cleaned };
   }
 
-  const duracaoEco = now() - inicioEco;
-  if (duracaoEco > 2500)
-    trackEcoDemorou({ userId, duracaoMs: duracaoEco, ultimaMsg });
-
-  const raw: string = data?.content ?? "";
-  let cleaned = stripIdentityCorrection(
-    formatarTextoEco(
-      limparResposta(
-        raw || "Desculpa, não consegui responder agora. Pode tentar de novo?"
-      )
-    ),
-    firstName(userName)
-  );
-  cleaned = stripRedundantGreeting(cleaned, hasAssistantBefore);
-
-  let bloco: any = null;
-  try {
-    bloco = await gerarBlocoTecnicoComCache(ultimaMsg, cleaned);
-  } catch {}
-
-  const response: GetEcoResult = { message: cleaned };
-  if (bloco && typeof bloco.intensidade === "number") {
-    response.intensidade = bloco.intensidade;
-    response.resumo = bloco?.analise_resumo?.trim().length
-      ? bloco.analise_resumo.trim()
-      : cleaned;
-    response.emocao = bloco.emocao_principal || "indefinida";
-    response.tags = Array.isArray(bloco.tags) ? bloco.tags : [];
-    response.categoria = bloco.categoria ?? null;
-  } else if (bloco) {
-    response.categoria = bloco.categoria ?? null;
+  if (isDebug()) {
+    log.debug("[Orchestrator] resposta pronta", {
+      duracaoEcoMs: now() - inicioEco,
+      lenMensagem: (data?.content || "").length,
+    });
   }
 
-  (async () => {
-    try {
-      if (userId) {
-        await saveMemoryOrReference({
-          supabase,
-          userId,
-          lastMessageId: (messages as any).at(-1)?.id ?? undefined,
-          cleaned,
-          bloco,
-          ultimaMsg,
-        });
-      }
-    } catch (e) {
-      log.warn("⚠️ Pós-processo falhou:", (e as Error).message);
-    }
-  })();
-
-  trackMensagemEnviada({
+  return defaultResponseFinalizer.finalize({
+    raw: data?.content ?? "",
+    ultimaMsg,
+    userName,
+    hasAssistantBefore: decision.hasAssistantBefore,
     userId,
-    tempoRespostaMs: duracaoEco,
-    tokensUsados: data?.usage?.total_tokens ?? undefined,
+    supabase,
+    lastMessageId: (messages as any).at(-1)?.id ?? undefined,
+    mode: "full",
+    startedAt: inicioEco,
+    usageTokens: data?.usage?.total_tokens ?? undefined,
     modelo: data?.model,
   });
-
-  if (isDebug())
-    log.debug("[Orchestrator] resposta pronta", {
-      duracaoEcoMs: duracaoEco,
-      lenMensagem: (cleaned || "").length,
-    });
-
-  return response;
 }
 
 export { getEcoResponse as getEcoResponseOtimizado };

--- a/server/services/conversation/contextCache.ts
+++ b/server/services/conversation/contextCache.ts
@@ -1,0 +1,80 @@
+import { PROMPT_CACHE } from "../CacheService";
+import { ContextBuilder } from "../promptContext";
+import { derivarNivel, detectarSaudacaoBreve } from "../promptContext/Selector";
+import { isDebug, log } from "../promptContext/logger";
+
+export interface ContextCacheParams {
+  userId?: string;
+  userName?: string;
+  perfil?: any;
+  mems?: any[];
+  memoriasSemelhantes?: any[];
+  forcarMetodoViva?: boolean;
+  blocoTecnicoForcado?: any;
+  texto: string;
+  heuristicas?: any[];
+  userEmbedding?: number[];
+  skipSaudacao?: boolean;
+  derivados?: any;
+  aberturaHibrida?: any;
+}
+
+interface ContextCacheDeps {
+  cache: typeof PROMPT_CACHE;
+  builder: typeof ContextBuilder;
+  logger: typeof log;
+  debug: typeof isDebug;
+}
+
+export class ContextCache {
+  constructor(
+    private readonly deps: ContextCacheDeps = {
+      cache: PROMPT_CACHE,
+      builder: ContextBuilder,
+      logger: log,
+      debug: isDebug,
+    }
+  ) {}
+
+  async build(params: ContextCacheParams) {
+    const entrada = String(params.texto ?? "");
+    const saudacaoBreve = detectarSaudacaoBreve(entrada);
+    const nivel = derivarNivel(entrada, saudacaoBreve);
+    const intensidade = Math.max(
+      0,
+      ...(params.mems ?? []).map((m: any) => Number(m?.intensidade ?? 0))
+    );
+
+    const msCount = Array.isArray(params.memoriasSemelhantes)
+      ? params.memoriasSemelhantes.length
+      : 0;
+
+    const cacheKey = `ctx:${params.userId || "anon"}:${nivel}:${Math.round(
+      intensidade
+    )}:ms${msCount}`;
+
+    const cached = this.deps.cache.get(cacheKey);
+    if (cached && msCount === 0) {
+      if (this.deps.debug()) {
+        this.deps.logger.debug("[Orchestrator] contexto via cache", { cacheKey });
+      }
+      return cached;
+    }
+
+    const t0 = Date.now();
+    const contexto = await this.deps.builder.build(params as any);
+    if (this.deps.debug()) {
+      this.deps.logger.debug("[Orchestrator] contexto construído", {
+        ms: Date.now() - t0,
+      });
+    }
+
+    if (nivel <= 2 && msCount === 0) {
+      this.deps.cache.set(cacheKey, contexto);
+    }
+
+    return contexto;
+  }
+}
+
+export const defaultContextCache = new ContextCache();

--- a/server/services/conversation/greeting.ts
+++ b/server/services/conversation/greeting.ts
@@ -1,0 +1,89 @@
+import { mapRoleForOpenAI } from "../../utils";
+import { GreetGuard } from "../../core/policies/GreetGuard";
+import {
+  respostaSaudacaoAutomatica,
+  type Msg as SaudacaoMsg,
+} from "../../utils/respostaSaudacaoAutomatica";
+
+export interface GreetingPipelineParams {
+  messages: Array<{ role: any; content: string }>;
+  ultimaMsg: string;
+  userId?: string;
+  userName?: string;
+  clientHour?: number | string | null;
+  greetingEnabled: boolean;
+}
+
+export interface GreetingPipelineResult {
+  handled: boolean;
+  response?: string;
+}
+
+export class GreetingPipeline {
+  constructor(private readonly guard = GreetGuard) {}
+
+  handle({
+    messages,
+    ultimaMsg,
+    userId,
+    userName,
+    clientHour,
+    greetingEnabled,
+  }: GreetingPipelineParams): GreetingPipelineResult {
+    if (!greetingEnabled) {
+      return { handled: false };
+    }
+
+    const assistantCount = messages.filter(
+      (m) => mapRoleForOpenAI(m.role) === "assistant"
+    ).length;
+    const threadVazia = assistantCount === 0;
+
+    const ultima = (ultimaMsg || "").trim();
+    const saudacaoCurta = /^\s*(oi|olá|ola|bom dia|boa tarde|boa noite)\s*[!.?]*$/i.test(
+      ultima
+    );
+    const conteudoSubstantivo =
+      /[?]|(\b(quero|preciso|como|por que|porque|ajuda|planejar|plano|passo|sinto|penso|lembro)\b)/i.test(
+        ultima
+      ) || ultima.split(/\s+/).length > 6;
+
+    const saudaMsgs: SaudacaoMsg[] = messages.slice(-4).map((m) => ({
+      role: this.toSaudRole(m.role),
+      content: m.content || "",
+    }));
+
+    const auto = respostaSaudacaoAutomatica({
+      messages: saudaMsgs,
+      userName,
+      clientHour,
+    });
+
+    if (auto?.meta?.isFarewell) {
+      return { handled: true, response: auto.text };
+    }
+
+    if (
+      auto?.meta?.isGreeting &&
+      threadVazia &&
+      (saudacaoCurta || ultima.length === 0) &&
+      !conteudoSubstantivo &&
+      this.guard.can(userId)
+    ) {
+      this.guard.mark(userId);
+      return { handled: true, response: auto.text };
+    }
+
+    return { handled: false };
+  }
+
+  private toSaudRole(role: any): SaudacaoMsg["role"] {
+    const mapped = mapRoleForOpenAI(role);
+    if (mapped === "user" || mapped === "assistant" || mapped === "system") {
+      return mapped;
+    }
+    return undefined;
+  }
+}
+
+export const defaultGreetingPipeline = new GreetingPipeline();

--- a/server/services/conversation/helpers.ts
+++ b/server/services/conversation/helpers.ts
@@ -1,0 +1,56 @@
+export function firstName(name?: string): string {
+  return (name || "").trim().split(/\s+/)[0] || "";
+}
+
+export function stripIdentityCorrection(text: string, nome?: string): string {
+  if (!nome) return text;
+  const re = new RegExp(
+    String.raw`(?:^|\n).*?(?:eu\s*)?sou\s*a?\s*eco[^.\n]*não\s+o?a?\s*${nome}\b.*`,
+    "i"
+  );
+  return text.replace(re, "").trim();
+}
+
+export function stripRedundantGreeting(
+  text: string,
+  hasAssistantBefore: boolean
+): string {
+  if (!hasAssistantBefore) return text;
+  let out = text.replace(
+    /^\s*(?:oi|olá|ola|bom dia|boa tarde|boa noite)[,!\.\-\–—\s]+/i,
+    ""
+  );
+  out = out.trim();
+  return out.length ? out : text;
+}
+
+export function isLowComplexity(texto: string): boolean {
+  const t = (texto || "").trim();
+  if (t.length <= 140) return true;
+  const words = t.split(/\s+/).length;
+  if (words <= 22) return true;
+  return !/crise|p[aâ]nico|desesper|vontade de sumir|explod|insuport|plano detalhado|passo a passo/i.test(
+    t
+  );
+}
+
+export function heuristicaPreViva(texto: string): boolean {
+  const lower = (texto || "").toLowerCase();
+  const len = lower.length;
+  const gatilhos = [
+    /ang[uú]st/i,
+    /p[aâ]nico/i,
+    /desesper/i,
+    /crise/i,
+    /sofr/i,
+    /n[aã]o aguento/i,
+    /vontade de sumir/i,
+    /explod/i,
+    /impulsiv/i,
+    /medo/i,
+    /ansiedad/i,
+    /culpa/i,
+    /triste/i,
+  ];
+  return gatilhos.some((regex) => regex.test(lower)) || len >= 180;
+}

--- a/server/services/conversation/parallelFetch.ts
+++ b/server/services/conversation/parallelFetch.ts
@@ -1,0 +1,101 @@
+import { isDebug, log } from "../promptContext/logger";
+import { getEmbeddingCached } from "../../adapters/EmbeddingAdapter";
+import { buscarHeuristicasSemelhantes } from "../../services/heuristicaService";
+import { buscarMemoriasSemelhantes } from "../../services/buscarMemorias";
+
+export interface ParallelFetchParams {
+  ultimaMsg: string;
+  userId?: string;
+  supabase?: any;
+}
+
+export interface ParallelFetchResult {
+  heuristicas: any[];
+  userEmbedding: number[];
+  memsSemelhantes: any[];
+}
+
+interface ParallelFetchDeps {
+  getEmbedding: typeof getEmbeddingCached;
+  getHeuristicas: typeof buscarHeuristicasSemelhantes;
+  getMemorias: typeof buscarMemoriasSemelhantes;
+  logger: typeof log;
+  debug: typeof isDebug;
+}
+
+export class ParallelFetchService {
+  constructor(
+    private readonly deps: ParallelFetchDeps = {
+      getEmbedding: getEmbeddingCached,
+      getHeuristicas: buscarHeuristicasSemelhantes,
+      getMemorias: buscarMemoriasSemelhantes,
+      logger: log,
+      debug: isDebug,
+    }
+  ) {}
+
+  async run({ ultimaMsg, userId, supabase }: ParallelFetchParams): Promise<ParallelFetchResult> {
+    let userEmbedding: number[] = [];
+    const trimmed = (ultimaMsg || "").trim();
+    if (trimmed.length > 0) {
+      userEmbedding = await this.deps.getEmbedding(trimmed, "entrada_usuario");
+    }
+
+    let heuristicas: any[] = [];
+    let memsSemelhantes: any[] = [];
+
+    if (userEmbedding.length > 0) {
+      try {
+        heuristicas = await this.deps.getHeuristicas({
+          usuarioId: userId ?? null,
+          userEmbedding,
+          matchCount: 5,
+        });
+      } catch {
+        heuristicas = [];
+      }
+
+      if (userId) {
+        try {
+          memsSemelhantes = await this.deps.getMemorias(userId, {
+            texto: trimmed,
+            k: 3,
+            threshold: 0.12,
+            supabaseClient: supabase,
+          });
+        } catch (e: any) {
+          if (this.deps.debug()) {
+            this.deps.logger.warn(
+              `[ParallelFetch] buscarMemoriasSemelhantes falhou: ${e?.message}`
+            );
+          }
+          memsSemelhantes = [];
+        }
+      }
+    }
+
+    return { heuristicas, userEmbedding, memsSemelhantes };
+  }
+}
+
+export async function withTimeoutOrNull<T>(
+  promise: Promise<T>,
+  ms: number,
+  label = "tarefa",
+  deps: { logger?: typeof log } = {}
+): Promise<T | null> {
+  const logger = deps.logger ?? log;
+  try {
+    return (await Promise.race([
+      promise,
+      new Promise<T>((_, reject) =>
+        setTimeout(() => reject(new Error(`${label} timeout ${ms}ms`)), ms)
+      ),
+    ])) as T;
+  } catch (e: any) {
+    logger.warn(`[Orchestrator] ${label} falhou/timeout (${ms}ms): ${e?.message}`);
+    return null;
+  }
+}
+
+export const defaultParallelFetchService = new ParallelFetchService();

--- a/server/services/conversation/responseFinalizer.ts
+++ b/server/services/conversation/responseFinalizer.ts
@@ -1,0 +1,127 @@
+import { formatarTextoEco, limparResposta, now } from "../../utils";
+import { gerarBlocoTecnicoComCache } from "../../core/EmotionalAnalyzer";
+import { saveMemoryOrReference } from "../../services/MemoryService";
+import {
+  trackEcoDemorou,
+  trackMensagemEnviada,
+} from "../../analytics/events/mixpanelEvents";
+import { log } from "../promptContext/logger";
+import {
+  firstName,
+  stripIdentityCorrection,
+  stripRedundantGreeting,
+} from "./helpers";
+import type { GetEcoResult } from "../../utils";
+
+interface ResponseFinalizerDeps {
+  gerarBlocoTecnicoComCache: typeof gerarBlocoTecnicoComCache;
+  saveMemoryOrReference: typeof saveMemoryOrReference;
+  trackMensagemEnviada: typeof trackMensagemEnviada;
+  trackEcoDemorou: typeof trackEcoDemorou;
+}
+
+export interface FinalizeParams {
+  raw: string;
+  ultimaMsg: string;
+  userName?: string;
+  hasAssistantBefore: boolean;
+  userId?: string;
+  supabase?: any;
+  lastMessageId?: string;
+  mode: "fast" | "full";
+  startedAt: number;
+  usageTokens?: number;
+  modelo?: string;
+  trackDelayThresholdMs?: number;
+  skipBloco?: boolean;
+}
+
+export class ResponseFinalizer {
+  constructor(
+    private readonly deps: ResponseFinalizerDeps = {
+      gerarBlocoTecnicoComCache,
+      saveMemoryOrReference,
+      trackMensagemEnviada,
+      trackEcoDemorou,
+    }
+  ) {}
+
+  async finalize({
+    raw,
+    ultimaMsg,
+    userName,
+    hasAssistantBefore,
+    userId,
+    supabase,
+    lastMessageId,
+    mode,
+    startedAt,
+    usageTokens,
+    modelo,
+    trackDelayThresholdMs = 2500,
+    skipBloco = false,
+  }: FinalizeParams): Promise<GetEcoResult> {
+    const base = formatarTextoEco(
+      limparResposta(
+        raw || "Desculpa, não consegui responder agora. Pode tentar de novo?"
+      )
+    );
+    const nome = firstName(userName);
+    const identityCleaned = stripIdentityCorrection(base, nome);
+    const cleaned = stripRedundantGreeting(identityCleaned, hasAssistantBefore);
+    const blocoTarget = mode === "fast" ? identityCleaned : cleaned;
+
+    let bloco: any = null;
+    if (!skipBloco) {
+      try {
+        bloco = await this.deps.gerarBlocoTecnicoComCache(ultimaMsg, blocoTarget);
+      } catch {}
+    }
+
+    const response: GetEcoResult = { message: cleaned };
+    if (bloco && typeof bloco.intensidade === "number") {
+      response.intensidade = bloco.intensidade;
+      response.resumo = bloco?.analise_resumo?.trim().length
+        ? bloco.analise_resumo.trim()
+        : cleaned;
+      response.emocao = bloco.emocao_principal || "indefinida";
+      response.tags = Array.isArray(bloco.tags) ? bloco.tags : [];
+      response.categoria = bloco.categoria ?? null;
+    } else if (bloco) {
+      response.categoria = bloco.categoria ?? null;
+    }
+
+    const duracao = now() - startedAt;
+    if (mode === "full" && duracao > trackDelayThresholdMs) {
+      this.deps.trackEcoDemorou({ userId, duracaoMs: duracao, ultimaMsg });
+    }
+
+    this.deps.trackMensagemEnviada({
+      userId,
+      tempoRespostaMs: duracao,
+      tokensUsados: usageTokens,
+      modelo,
+    });
+
+    if (userId) {
+      (async () => {
+        try {
+          await this.deps.saveMemoryOrReference({
+            supabase,
+            userId,
+            lastMessageId,
+            cleaned,
+            bloco,
+            ultimaMsg,
+          });
+        } catch (e) {
+          log.warn("⚠️ Pós-processo falhou:", (e as Error).message);
+        }
+      })();
+    }
+
+    return response;
+  }
+}
+
+export const defaultResponseFinalizer = new ResponseFinalizer();

--- a/server/services/conversation/router.ts
+++ b/server/services/conversation/router.ts
@@ -1,0 +1,55 @@
+import { mapRoleForOpenAI } from "../../utils";
+import { derivarNivel, detectarSaudacaoBreve } from "../promptContext/Selector";
+import { heuristicaPreViva, isLowComplexity } from "./helpers";
+
+export interface RouteDecisionParams {
+  messages: Array<{ role: any; content: string }>;
+  ultimaMsg: string;
+  forcarMetodoViva?: boolean;
+  promptOverride?: string | null;
+}
+
+export interface RouteDecision {
+  mode: "fast" | "full";
+  hasAssistantBefore: boolean;
+  vivaAtivo: boolean;
+  lowComplexity: boolean;
+  nivelRoteador: number | null;
+  forceFull: boolean;
+}
+
+export class ConversationRouter {
+  decide({
+    messages,
+    ultimaMsg,
+    forcarMetodoViva,
+    promptOverride,
+  }: RouteDecisionParams): RouteDecision {
+    const saudacaoBreve = detectarSaudacaoBreve(ultimaMsg);
+    const nivelRoteador = derivarNivel(ultimaMsg, saudacaoBreve);
+    const lowComplexity = isLowComplexity(ultimaMsg);
+    const vivaAtivo = Boolean(forcarMetodoViva || heuristicaPreViva(ultimaMsg));
+
+    const forceFull = Boolean(promptOverride && promptOverride.trim().length > 0);
+
+    const hasAssistantBefore =
+      messages.filter((m) => mapRoleForOpenAI(m.role) === "assistant").length > 0;
+
+    const canFastLane =
+      !forceFull &&
+      lowComplexity &&
+      !vivaAtivo &&
+      (typeof nivelRoteador === "number" ? nivelRoteador <= 1 : true);
+
+    return {
+      mode: canFastLane ? "fast" : "full",
+      hasAssistantBefore,
+      vivaAtivo,
+      lowComplexity,
+      nivelRoteador: typeof nivelRoteador === "number" ? nivelRoteador : null,
+      forceFull,
+    };
+  }
+}
+
+export const defaultConversationRouter = new ConversationRouter();


### PR DESCRIPTION
## Summary
- document the current responsibilities of `ConversationOrchestrator.ts`
- propose module boundaries to split greeting, routing, parallel fetch, and response finalization
- outline testing and isolation strategies for the extracted components

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d69016d2d08325b3ea44bbe43ad42a