### PR TITLE
Parallelize derivados supabase fetches

### DIFF
--- a/server/services/ConversationOrchestrator.ts
+++ b/server/services/ConversationOrchestrator.ts
@@ -217,26 +217,27 @@ export async function getEcoResponse(
     : await withTimeoutOrNull(
         (async () => {
           try {
-            const { data: stats } = await supabase
-              .from("user_theme_stats")
-              .select("tema,freq_30d,int_media_30d")
-              .eq("user_id", userId)
-              .order("freq_30d", { ascending: false })
-              .limit(5);
-
-            const { data: marcos } = await supabase
-              .from("user_temporal_milestones")
-              .select("tema,resumo_evolucao,marco_at")
-              .eq("user_id", userId)
-              .order("marco_at", { ascending: false })
-              .limit(3);
-
-            const { data: efeitos } = await supabase
-              .from("interaction_effects")
-              .select("efeito,score,created_at")
-              .eq("user_id", userId)
-              .order("created_at", { ascending: false })
-              .limit(30);
+            const [{ data: stats }, { data: marcos }, { data: efeitos }] =
+              await Promise.all([
+                supabase
+                  .from("user_theme_stats")
+                  .select("tema,freq_30d,int_media_30d")
+                  .eq("user_id", userId)
+                  .order("freq_30d", { ascending: false })
+                  .limit(5),
+                supabase
+                  .from("user_temporal_milestones")
+                  .select("tema,resumo_evolucao,marco_at")
+                  .eq("user_id", userId)
+                  .order("marco_at", { ascending: false })
+                  .limit(3),
+                supabase
+                  .from("interaction_effects")
+                  .select("efeito,score,created_at")
+                  .eq("user_id", userId)
+                  .order("created_at", { ascending: false })
+                  .limit(30),
+              ]);
 
             const arr = (efeitos || []).map((r: any) => ({
               x: { efeito: (r.efeito as any) ?? "neutro" },


### PR DESCRIPTION
## Summary
- fetch user theme stats, milestones, and interaction effects in parallel when assembling derivados
- keep the downstream derivados calculations and timeout fallback unchanged

## Testing
- npx ts-node --project server/tsconfig.json -e "import { getDerivados } from './server/services/derivadosService'; (async () => { const res = await getDerivados([{ tema: 'autoconhecimento', freq_30d: 5, int_media_30d: 0.5 }], [{ tema: 'propósito', resumo_evolucao: 'você tem focado no essencial', marco_at: '2024-01-01' }], [{ x: { efeito: 'abriu' } }, { x: { efeito: 'neutro' } }], 0.42); console.log(Object.keys(res)); console.log(res); })();"

------
https://chatgpt.com/codex/tasks/task_e_68d9859e39a48325a6f15e825764b872