### PR TITLE
Reuse computed embedding when fetching memories

### DIFF
--- a/server/services/conversation/parallelFetch.ts
+++ b/server/services/conversation/parallelFetch.ts
@@ -56,7 +56,9 @@ export class ParallelFetchService {
       const memsPromise = userId
         ? this.deps
             .getMemorias(userId, {
+              // Reuse the embedding computed above to avoid duplicate embedding API calls.
               texto: trimmed,
+              userEmbedding,
               k: 3,
               threshold: 0.12,
               supabaseClient: supabase,


### PR DESCRIPTION
## Summary
- pass the computed user embedding into the memory lookup to reuse the vector
- document the embedding reuse to highlight the avoided duplicate API work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d988285db48325b2eab34362eae05b