### PR TITLE
Add personalized user name reminder to prompt context

### DIFF
--- a/server/services/promptContext/ContextBuilder.ts
+++ b/server/services/promptContext/ContextBuilder.ts
@@ -1,4 +1,5 @@
 // server/services/promptContext/ContextBuilder.ts
+import { firstName } from "../conversation/helpers";
 import { isDebug, log } from "./logger";
 import { Selector, derivarNivel, detectarSaudacaoBreve } from "./Selector";
 import type { BuildParams } from "./contextTypes";
@@ -82,6 +83,10 @@ export async function montarContextoEco(params: BuildParams): Promise<string> {
   const instructionText = renderInstructionBlocks(instructionBlocks);
 
   const extras: string[] = [];
+  const nomeUsuario = firstName(params.userName ?? undefined);
+  if (nomeUsuario) {
+    extras.push(`Usuário se chama ${nomeUsuario}; use o nome apenas quando fizer sentido.`);
+  }
   if (aberturaHibrida?.sugestaoNivel != null) {
     extras.push(`Ajuste dinâmico de abertura (sugerido): ${aberturaHibrida.sugestaoNivel}`);
   }

--- a/server/tests/promptContext/ContextBuilder.test.ts
+++ b/server/tests/promptContext/ContextBuilder.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import montarContextoEco from "../../services/promptContext/ContextBuilder";
+import { ModuleStore } from "../../services/promptContext/ModuleStore";
+
+const inlineModules: Record<string, string> = {
+  "NV1_CORE.txt": "Conteúdo NV1 core",
+  "IDENTIDADE_MINI.txt": "Conteúdo identidade mini",
+  "ANTISALDO_MIN.txt": "Conteúdo antissaldo mínimo",
+  "ESCALA_ABERTURA_1a3.txt": "Conteúdo escala de abertura",
+};
+
+ModuleStore.configure([]);
+for (const [name, content] of Object.entries(inlineModules)) {
+  ModuleStore.registerInline(name, content);
+}
+
+const params = {
+  userName: "Maria Clara Silva",
+  texto: "Oi, tudo bem?",
+  mems: [],
+};
+
+test("ContextBuilder inclui lembrete com o nome do usuário", async () => {
+  const prompt = await montarContextoEco(params);
+  assert.match(
+    prompt,
+    /Usuário se chama Maria; use o nome apenas quando fizer sentido\./
+  );
+});


### PR DESCRIPTION
## Summary
- compute the user's first name when building the prompt context
- add the reminder to the extras block so the assistant can reference it sensibly
- cover the behavior with a focused ContextBuilder test

## Testing
- npx ts-node --compiler-options '{"module":"commonjs"}' server/tests/promptContext/ContextBuilder.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d99858aa6083259da16bc186b8ec51