### PR TITLE
Refactor conversation prompt planning helper

### DIFF
--- a/server/services/conversation/promptPlan.ts
+++ b/server/services/conversation/promptPlan.ts
@@ -1,0 +1,56 @@
+import { mapRoleForOpenAI } from "../../utils";
+import type { RouteDecision } from "./router";
+
+type PromptMessage = { role: "system" | "user" | "assistant"; content: string };
+
+const STYLE_COACH =
+  "Preferir plano COACH (30%): acolher (1 linha) • encorajar com leveza • (opcional) até 3 passos curtos • fechar com incentivo.";
+const STYLE_ESPELHO =
+  "Preferir plano ESPELHO (70%): acolher (1 linha) • refletir padrões/sentimento (1 linha) • 1 pergunta aberta • fechar leve.";
+
+export function detectExplicitAskForSteps(text: string): boolean {
+  if (!text) return false;
+
+  const rx =
+    /\b(passos?|etapas?|como\s+fa(c|ç)o|como\s+fazer|checklist|guia|tutorial|roteiro|lista\s+de|me\s+mostra\s+como|o\s+que\s+fazer)\b/i;
+
+  return rx.test(text.normalize("NFD").replace(/[\u0300-\u036f]/g, ""));
+}
+
+export interface BuildFullPromptParams {
+  decision: RouteDecision;
+  ultimaMsg: string;
+  systemPrompt: string;
+  messages: Array<{ role: any; content: string }>;
+  historyLimit?: number;
+}
+
+export function buildFullPrompt({
+  decision,
+  ultimaMsg,
+  systemPrompt,
+  messages,
+  historyLimit = 5,
+}: BuildFullPromptParams): { prompt: PromptMessage[]; maxTokens: number } {
+  const explicitAskForSteps = detectExplicitAskForSteps(ultimaMsg);
+  const preferCoachFull =
+    !decision.vivaAtivo &&
+    (explicitAskForSteps || Number(decision.nivelRoteador) === 1);
+
+  const STYLE_SELECTOR_FULL = preferCoachFull ? STYLE_COACH : STYLE_ESPELHO;
+
+  const history = (messages ?? []).slice(-historyLimit).map((m) => ({
+    role: mapRoleForOpenAI(m.role) as PromptMessage["role"],
+    content: m.content,
+  }));
+
+  const prompt: PromptMessage[] = [
+    { role: "system", content: `${STYLE_SELECTOR_FULL}\n${systemPrompt}` },
+    ...history,
+  ];
+
+  const ultimaLen = ultimaMsg ? ultimaMsg.length : 0;
+  const maxTokens = ultimaLen < 140 ? 420 : ultimaLen < 280 ? 560 : 700;
+
+  return { prompt, maxTokens };
+}

--- a/server/tests/conversation/promptPlan.test.ts
+++ b/server/tests/conversation/promptPlan.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { buildFullPrompt } from "../../services/conversation/promptPlan";
+import type { RouteDecision } from "../../services/conversation/router";
+
+function createDecision(overrides: Partial<RouteDecision> = {}): RouteDecision {
+  return {
+    mode: "full",
+    hasAssistantBefore: false,
+    vivaAtivo: false,
+    lowComplexity: false,
+    nivelRoteador: 2,
+    forceFull: false,
+    ...overrides,
+  };
+}
+
+test("maxTokens respects length thresholds", () => {
+  const baseParams = {
+    decision: createDecision(),
+    systemPrompt: "Contexto acumulado",
+    messages: [],
+  };
+
+  const short = buildFullPrompt({
+    ...baseParams,
+    ultimaMsg: "Oi Eco",
+  });
+  assert.strictEqual(short.maxTokens, 420);
+
+  const medium = buildFullPrompt({
+    ...baseParams,
+    ultimaMsg: "x".repeat(200),
+  });
+  assert.strictEqual(medium.maxTokens, 560);
+
+  const long = buildFullPrompt({
+    ...baseParams,
+    ultimaMsg: "x".repeat(400),
+  });
+  assert.strictEqual(long.maxTokens, 700);
+});
+
+test("seleciona estilo coach quando usuário pede passos e viva está desligado", () => {
+  const { prompt } = buildFullPrompt({
+    decision: createDecision(),
+    ultimaMsg: "Pode me dar passos concretos?",
+    systemPrompt: "Contexto cacheado",
+    messages: [
+      { role: "user", content: "Mensagem antiga" },
+      { role: "assistant", content: "Resposta antiga" },
+    ],
+    historyLimit: 1,
+  });
+
+  assert.ok(prompt[0].content.startsWith("Preferir plano COACH"));
+  assert.strictEqual(prompt.length, 1 + 1);
+  assert.strictEqual(prompt[1].content, "Resposta antiga");
+});
+
+test("mantém estilo espelho quando viva está ativo", () => {
+  const { prompt } = buildFullPrompt({
+    decision: createDecision({ vivaAtivo: true }),
+    ultimaMsg: "Pode me dar passos concretos?",
+    systemPrompt: "Contexto cacheado",
+    messages: [],
+  });
+
+  assert.ok(prompt[0].content.startsWith("Preferir plano ESPELHO"));
+});
+
+test("system prompt combina seletor de estilo e contexto", () => {
+  const contexto = "Contexto da cache";
+  const { prompt } = buildFullPrompt({
+    decision: createDecision({ nivelRoteador: 1 }),
+    ultimaMsg: "Tudo bem?",
+    systemPrompt: contexto,
+    messages: [],
+  });
+
+  assert.strictEqual(prompt[0].content, `Preferir plano COACH (30%): acolher (1 linha) • encorajar com leveza • (opcional) até 3 passos curtos • fechar com incentivo.\n${contexto}`);
+});


### PR DESCRIPTION
## Summary
- extract full prompt construction to server/services/conversation/promptPlan.ts to encapsulate style selection, history trimming, and token budgeting
- update the conversation orchestrator to reuse the new helper and share the ask-for-steps detector
- add focused tests that cover max token thresholds, coach vs. espelho selection, and system prompt formatting

## Testing
- node --test --require ts-node/register server/tests/conversation/promptPlan.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9a480af1c8325819c43c890f45d98