### PR TITLE
Refactor fast-lane conversation flow

### DIFF
--- a/server/services/conversation/fastLane.ts
+++ b/server/services/conversation/fastLane.ts
@@ -1,0 +1,163 @@
+import { mapRoleForOpenAI, type GetEcoResult } from "../../utils";
+import { log } from "../promptContext/logger";
+import type { FinalizeParams } from "./responseFinalizer";
+
+type ClaudeMessage = { role: "system" | "user" | "assistant"; content: string };
+
+type ClaudeClientResult = {
+  content?: string;
+  usage?: { total_tokens?: number; [key: string]: unknown } | null;
+  model?: string;
+};
+
+type ClaudeClientParams = {
+  messages: ClaudeMessage[];
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+};
+
+export interface RunFastLaneLLMDeps {
+  claudeClient: (params: ClaudeClientParams) => Promise<ClaudeClientResult>;
+  responseFinalizer: { finalize: (params: FinalizeParams) => Promise<GetEcoResult> };
+  firstName: (fullName?: string) => string | undefined;
+}
+
+export interface RunFastLaneLLMParams {
+  messages: Array<{ role: string; content: string; id?: string }>;
+  userName?: string;
+  ultimaMsg: string;
+  hasAssistantBefore: boolean;
+  userId?: string;
+  supabase?: any;
+  lastMessageId?: string;
+  startedAt: number;
+  deps: RunFastLaneLLMDeps;
+}
+
+export interface RunFastLaneLLMResult {
+  raw: string;
+  usage?: { total_tokens?: number; [key: string]: unknown } | null;
+  model?: string;
+  response: GetEcoResult;
+}
+
+const ASK_FOR_STEPS_REGEX =
+  /\b(passos?|etapas?|como\s+fa(c|ç)o|como\s+fazer|checklist|guia|tutorial|roteiro|lista\s+de|me\s+mostra\s+como|o\s+que\s+fazer)\b/i;
+
+const ID_ECO_MINI =
+  "Você é a Eco: espelho socrático de autoconhecimento — reflexiva, curiosa e acolhedora. " +
+  "Proporção: 70% espelho (devolver padrões, clarear percepções) + 30% coach gentil (encorajamento, humor leve). " +
+  "Tom: reflexivo, claro, acolhedor, levemente bem-humorado. Use português brasileiro natural. " +
+  "Cultive: escuta paciente, curiosidade filosófica, espelhamento sensível, incentivo leve. " +
+  "Evite: linguagem robótica, jargões de coaching, prescrições, diagnósticos e substituir terapia. " +
+  "Objetivo: criar um espaço seguro de reflexão para o usuário se ver com mais clareza, com companhia curiosa e respeitosa.";
+
+const STYLE_HINTS_MINI =
+  "Responda curto (1–2 frases) quando possível, claro e acolhedor. Se pedirem passos, no máximo 3 itens.";
+
+export function detectExplicitAskForSteps(text: string): boolean {
+  if (!text) return false;
+  const normalized = text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  return ASK_FOR_STEPS_REGEX.test(normalized);
+}
+
+function buildStyleSelector(preferCoach: boolean): string {
+  return preferCoach
+    ? "Preferir plano COACH (30%): acolher (1 linha) • encorajar com leveza • (opcional) até 3 passos curtos • fechar com incentivo."
+    : "Preferir plano ESPELHO (70%): acolher (1 linha) • refletir padrões/sentimento (1 linha) • 1 pergunta aberta • fechar leve.";
+}
+
+function montarSystemMessage({
+  preferCoach,
+  nome,
+}: {
+  preferCoach: boolean;
+  nome?: string;
+}): string {
+  const style = buildStyleSelector(preferCoach);
+  const nameHint = nome
+    ? `O usuário se chama ${nome}. Use o nome apenas quando fizer sentido. Nunca corrija nomes nem diga frases como 'sou a Eco, não o ${nome}'. `
+    : "Nunca corrija nomes. ";
+
+  return `${style} ${ID_ECO_MINI} ${STYLE_HINTS_MINI} ${nameHint}`;
+}
+
+function montarSlimHistory(messages: RunFastLaneLLMParams["messages"]): ClaudeMessage[] {
+  const history = Array.isArray(messages) ? messages : [];
+  const turns = history.slice(-3).map((m) => ({
+    role: mapRoleForOpenAI(m.role) as ClaudeMessage["role"],
+    content: m.content,
+  }));
+
+  return turns;
+}
+
+export async function runFastLaneLLM({
+  messages,
+  userName,
+  ultimaMsg,
+  hasAssistantBefore,
+  userId,
+  supabase,
+  lastMessageId,
+  startedAt,
+  deps,
+}: RunFastLaneLLMParams): Promise<RunFastLaneLLMResult> {
+  const nome = deps.firstName?.(userName);
+  const preferCoach = detectExplicitAskForSteps(ultimaMsg);
+  const system = montarSystemMessage({ preferCoach, nome });
+  const slimHistory = montarSlimHistory(messages);
+
+  const payload: ClaudeClientParams = {
+    messages: [{ role: "system", content: system }, ...slimHistory],
+    model: process.env.ECO_FAST_MODEL || "anthropic/claude-3-5-haiku",
+    temperature: 0.5,
+    maxTokens: 220,
+  };
+
+  let completion: ClaudeClientResult | undefined;
+  try {
+    completion = await deps.claudeClient(payload);
+  } catch (error: any) {
+    log.warn(`[fastLaneLLM] falhou: ${error?.message}`);
+    const fallback = "Tô aqui com você. Quer me contar um pouco mais?";
+    const response = await deps.responseFinalizer.finalize({
+      raw: fallback,
+      ultimaMsg,
+      userName,
+      hasAssistantBefore,
+      userId,
+      supabase,
+      lastMessageId,
+      mode: "fast",
+      startedAt,
+      usageTokens: undefined,
+      modelo: "fastlane-fallback",
+    });
+
+    return { raw: fallback, usage: null, model: "fastlane-fallback", response };
+  }
+
+  const raw = completion?.content ?? "";
+  const usage = completion?.usage ?? null;
+  const model = completion?.model;
+
+  const response = await deps.responseFinalizer.finalize({
+    raw,
+    ultimaMsg,
+    userName,
+    hasAssistantBefore,
+    userId,
+    supabase,
+    lastMessageId,
+    mode: "fast",
+    startedAt,
+    usageTokens: usage?.total_tokens ?? undefined,
+    modelo: model,
+  });
+
+  return { raw, usage, model, response };
+}
+
+export type { ClaudeClientParams, ClaudeClientResult };

--- a/server/tests/conversation/fastLane.test.ts
+++ b/server/tests/conversation/fastLane.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import {
+  detectExplicitAskForSteps,
+  runFastLaneLLM,
+  type RunFastLaneLLMResult,
+} from "../../services/conversation/fastLane";
+
+function createDeps(overrides: Partial<{
+  claudeClient: any;
+  responseFinalizer: any;
+  firstName: any;
+}> = {}) {
+  const claudeCalls: any[] = [];
+  const finalizeCalls: any[] = [];
+
+  const claudeClient = overrides.claudeClient
+    ? overrides.claudeClient
+    : async (params: any) => {
+        claudeCalls.push(params);
+        return { content: "ok", usage: { total_tokens: 42 }, model: "test-model" };
+      };
+
+  const responseFinalizer = overrides.responseFinalizer
+    ? overrides.responseFinalizer
+    : {
+        finalize: async (params: any) => {
+          finalizeCalls.push(params);
+          return { message: `final:${params.raw}` };
+        },
+      };
+
+  const firstName = overrides.firstName
+    ? overrides.firstName
+    : (value?: string) => value?.split(" ")[0] ?? "";
+
+  return {
+    claudeCalls,
+    finalizeCalls,
+    deps: {
+      claudeClient,
+      responseFinalizer,
+      firstName,
+    },
+  };
+}
+
+test("detectExplicitAskForSteps reconhece pedidos explícitos", () => {
+  assert.ok(detectExplicitAskForSteps("pode me mostrar os passos?"));
+  assert.ok(detectExplicitAskForSteps("como faço pra lidar com isso"));
+  assert.ok(detectExplicitAskForSteps("preciso de um guia ou checklist"));
+  assert.strictEqual(detectExplicitAskForSteps("quero refletir sobre um sentimento"), false);
+});
+
+test("runFastLaneLLM envia apenas as 3 últimas mensagens do histórico", async () => {
+  const history = [
+    { role: "user", content: "mensagem 1" },
+    { role: "assistant", content: "mensagem 2" },
+    { role: "user", content: "mensagem 3" },
+    { role: "assistant", content: "mensagem 4" },
+    { role: "user", content: "mensagem 5" },
+  ];
+
+  const { deps, claudeCalls, finalizeCalls } = createDeps();
+
+  const result = (await runFastLaneLLM({
+    messages: history,
+    userName: "Ana Maria",
+    ultimaMsg: "mensagem 5",
+    hasAssistantBefore: true,
+    userId: "user-123",
+    supabase: { tag: "db" },
+    lastMessageId: "msg-5",
+    startedAt: 1000,
+    deps,
+  })) as RunFastLaneLLMResult;
+
+  assert.strictEqual(claudeCalls.length, 1);
+  const sentMessages = claudeCalls[0].messages;
+  assert.strictEqual(sentMessages.length, 4); // system + 3 últimas mensagens
+  assert.deepStrictEqual(
+    sentMessages.slice(1).map((m: any) => m.content),
+    ["mensagem 3", "mensagem 4", "mensagem 5"]
+  );
+
+  assert.strictEqual(result.raw, "ok");
+  assert.deepStrictEqual(result.usage, { total_tokens: 42 });
+  assert.strictEqual(result.model, "test-model");
+  assert.deepStrictEqual(result.response, { message: "final:ok" });
+
+  assert.strictEqual(finalizeCalls.length, 1);
+  assert.strictEqual(finalizeCalls[0].raw, "ok");
+  assert.strictEqual(finalizeCalls[0].usageTokens, 42);
+  assert.strictEqual(finalizeCalls[0].modelo, "test-model");
+  assert.strictEqual(finalizeCalls[0].mode, "fast");
+});
+
+test("runFastLaneLLM usa fallback quando o cliente Claude falha", async () => {
+  const fallbackError = new Error("claude indisponível");
+  const fallbackCalls: any[] = [];
+
+  const { deps } = createDeps({
+    claudeClient: async () => {
+      throw fallbackError;
+    },
+    responseFinalizer: {
+      finalize: async (params: any) => {
+        fallbackCalls.push(params);
+        return { message: params.raw };
+      },
+    },
+  });
+
+  const result = await runFastLaneLLM({
+    messages: [{ role: "user", content: "oi" }],
+    userName: "João",
+    ultimaMsg: "oi",
+    hasAssistantBefore: false,
+    userId: "user-999",
+    supabase: null,
+    lastMessageId: undefined,
+    startedAt: 123,
+    deps,
+  });
+
+  assert.strictEqual(result.raw, "Tô aqui com você. Quer me contar um pouco mais?");
+  assert.strictEqual(result.model, "fastlane-fallback");
+  assert.strictEqual(result.usage, null);
+  assert.deepStrictEqual(result.response, {
+    message: "Tô aqui com você. Quer me contar um pouco mais?",
+  });
+  assert.strictEqual(fallbackCalls.length, 1);
+  assert.strictEqual(
+    fallbackCalls[0].modelo,
+    "fastlane-fallback",
+    "finalizer recebe modelo de fallback"
+  );
+});
+
+test("STYLE_SELECTOR alterna entre coach e espelho conforme o pedido", async () => {
+  const recordedSystems: string[] = [];
+
+  const claudeClient = async (params: any) => {
+    recordedSystems.push(params.messages[0].content);
+    return { content: "ok", usage: null, model: "style-test" };
+  };
+
+  const { deps } = createDeps({ claudeClient });
+
+  await runFastLaneLLM({
+    messages: [{ role: "user", content: "pode me dar passos?" }],
+    userName: "Carlos Silva",
+    ultimaMsg: "pode me dar passos?",
+    hasAssistantBefore: false,
+    userId: undefined,
+    supabase: undefined,
+    lastMessageId: undefined,
+    startedAt: 0,
+    deps,
+  });
+
+  await runFastLaneLLM({
+    messages: [{ role: "user", content: "quero apenas refletir" }],
+    userName: "Carlos Silva",
+    ultimaMsg: "quero apenas refletir",
+    hasAssistantBefore: false,
+    userId: undefined,
+    supabase: undefined,
+    lastMessageId: undefined,
+    startedAt: 0,
+    deps,
+  });
+
+  assert.strictEqual(recordedSystems.length, 2);
+  assert.ok(recordedSystems[0].includes("Preferir plano COACH"));
+  assert.ok(recordedSystems[1].includes("Preferir plano ESPELHO"));
+});


### PR DESCRIPTION
## Summary
- extract the fast-lane LLM helper into `conversation/fastLane` with dependency injection for the Claude client and response finalizer
- simplify the orchestrator fast path to delegate to `runFastLaneLLM`
- cover fast-lane behaviour with unit tests for step detection, history trimming, fallback, and style selection

## Testing
- node --test server/tests/conversation/fastLane.test.ts *(fails: Node.js cannot load ESM tests under the current CommonJS configuration)*
- npm run --prefix server build *(fails: pre-existing missing type definitions in the server package)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a46e80c88325a1ab0f4947dc3d62