### PR TITLE
Translate heuristic matches into selector flags

### DIFF
--- a/server/services/promptContext/ContextBuilder.ts
+++ b/server/services/promptContext/ContextBuilder.ts
@@ -2,6 +2,7 @@
 import { firstName } from "../conversation/helpers";
 import { isDebug, log } from "./logger";
 import { Selector, derivarNivel, detectarSaudacaoBreve } from "./Selector";
+import { mapHeuristicasToFlags } from "./heuristicaFlags";
 import type { BuildParams } from "./contextTypes";
 import { ModuleCatalog } from "./moduleCatalog";
 import { planBudget } from "./budget";
@@ -52,10 +53,12 @@ export async function montarContextoEco(params: BuildParams): Promise<string> {
 
   await ModuleCatalog.ensureReady();
 
+  const heuristicaFlags = mapHeuristicasToFlags(_heuristicas);
+
   const baseSelection = Selector.selecionarModulosBase({
     nivel,
     intensidade: memIntensity,
-    flags: Selector.derivarFlags(texto),
+    flags: Selector.derivarFlags(texto, heuristicaFlags),
   });
 
   const toUnique = (list: string[] | undefined) =>

--- a/server/services/promptContext/Selector.ts
+++ b/server/services/promptContext/Selector.ts
@@ -2,6 +2,7 @@
 
 import matrizPromptBaseV2 from "./matrizPromptBaseV2"; // ajuste o caminho se necessário
 import { Camada, CondicaoEspecial } from "./types";
+import type { HeuristicaFlagRecord } from "./heuristicaFlags";
 
 /* ===================== Tipos & Interfaces ===================== */
 
@@ -17,6 +18,13 @@ export type Flags = {
   desabafo: boolean;
   urgencia: boolean;
   emocao_alta_linguagem: boolean;
+
+  // 🔥 Heurísticas cognitivas (eco_heuristica_*.txt)
+  ancoragem: boolean;
+  causas_superam_estatisticas: boolean;
+  certeza_emocional: boolean;
+  excesso_intuicao_especialista: boolean;
+  ignora_regressao_media: boolean;
 };
 
 export type BaseSelection = {
@@ -88,7 +96,7 @@ export function derivarNivel(texto: string, saudacaoBreve: boolean): 1 | 2 | 3 {
 
 /* ===================== Flags ===================== */
 
-export function derivarFlags(texto: string): Flags {
+export function derivarFlags(texto: string, heuristicaFlags: HeuristicaFlagRecord = {}): Flags {
   const raw = texto || "";
   const t = normalize(raw);
 
@@ -132,6 +140,11 @@ export function derivarFlags(texto: string): Flags {
     desabafo,
     urgencia,
     emocao_alta_linguagem,
+    ancoragem: Boolean(heuristicaFlags.ancoragem),
+    causas_superam_estatisticas: Boolean(heuristicaFlags.causas_superam_estatisticas),
+    certeza_emocional: Boolean(heuristicaFlags.certeza_emocional),
+    excesso_intuicao_especialista: Boolean(heuristicaFlags.excesso_intuicao_especialista),
+    ignora_regressao_media: Boolean(heuristicaFlags.ignora_regressao_media),
   };
 }
 
@@ -158,6 +171,11 @@ type Ctx = {
   desabafo: boolean;
   urgencia: boolean;
   emocao_alta_linguagem: boolean;
+  ancoragem: boolean;
+  causas_superam_estatisticas: boolean;
+  certeza_emocional: boolean;
+  excesso_intuicao_especialista: boolean;
+  ignora_regressao_media: boolean;
 };
 
 function evalRule(rule: string, ctx: Ctx): boolean {
@@ -216,6 +234,11 @@ function readVarBool(name: string, ctx: Ctx): boolean | null {
     case "desabafo":
     case "urgencia":
     case "emocao_alta_linguagem":
+    case "ancoragem":
+    case "causas_superam_estatisticas":
+    case "certeza_emocional":
+    case "excesso_intuicao_especialista":
+    case "ignora_regressao_media":
       return Boolean((ctx as any)[name]);
     default:
       return null;

--- a/server/services/promptContext/heuristicaFlags.ts
+++ b/server/services/promptContext/heuristicaFlags.ts
@@ -1,0 +1,120 @@
+import { tagsPorHeuristica } from "../../assets/config/heuristicasTriggers";
+
+export const heuristicaFlagNames = [
+  "ancoragem",
+  "causas_superam_estatisticas",
+  "certeza_emocional",
+  "excesso_intuicao_especialista",
+  "ignora_regressao_media",
+] as const;
+
+export type HeuristicaFlagName = (typeof heuristicaFlagNames)[number];
+
+export type HeuristicaFlagRecord = Partial<Record<HeuristicaFlagName, boolean>>;
+
+const arquivoFlagPairs: Array<[string, HeuristicaFlagName]> = [
+  ["eco_heuristica_ancoragem.txt", "ancoragem"],
+  ["eco_heuristica_causas_superam_estatisticas.txt", "causas_superam_estatisticas"],
+  ["eco_heuristica_certeza_emocional.txt", "certeza_emocional"],
+  ["eco_heuristica_intuicao_especialista.txt", "excesso_intuicao_especialista"],
+  ["eco_heuristica_regressao_media.txt", "ignora_regressao_media"],
+];
+
+const arquivoToFlag: Record<string, HeuristicaFlagName> = (() => {
+  const map: Record<string, HeuristicaFlagName> = {};
+  for (const [arquivo, flag] of arquivoFlagPairs) {
+    const normalized = normalizeKey(arquivo);
+    if (!normalized) continue;
+    map[normalized] = flag;
+    if (normalized.endsWith(".txt")) {
+      const withoutExt = normalized.replace(/\.txt$/, "");
+      if (!map[withoutExt]) {
+        map[withoutExt] = flag;
+      }
+    }
+  }
+  return map;
+})();
+
+const tagToFlag: Record<string, HeuristicaFlagName> = (() => {
+  const map: Record<string, HeuristicaFlagName> = {};
+  for (const [arquivo, tags] of Object.entries(tagsPorHeuristica)) {
+    const flag = arquivoToFlag[normalizeKey(arquivo)];
+    if (!flag) continue;
+    for (const tag of tags ?? []) {
+      const key = normalizeKey(tag);
+      if (key) map[key] = flag;
+    }
+  }
+  return map;
+})();
+
+function normalizeKey(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase();
+}
+
+function collectCandidateStrings(entry: unknown): string[] {
+  if (!entry || typeof entry !== "object") return [];
+  const obj = entry as Record<string, unknown>;
+  const candidates: string[] = [];
+  ["arquivo", "file", "nome", "name", "id"].forEach((key) => {
+    const value = obj[key];
+    if (typeof value === "string") {
+      candidates.push(value);
+    }
+  });
+  return candidates;
+}
+
+function collectTags(entry: unknown): string[] {
+  if (!entry || typeof entry !== "object") return [];
+  const obj = entry as Record<string, unknown>;
+  const raw = obj["tags"];
+  if (Array.isArray(raw)) {
+    return raw.map((tag) => (typeof tag === "string" ? tag : "")).filter(Boolean);
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(/[,;]+/)
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function mapHeuristicasToFlags(heuristicas: unknown[]): HeuristicaFlagRecord {
+  const result: HeuristicaFlagRecord = {};
+  if (!Array.isArray(heuristicas) || heuristicas.length === 0) return result;
+
+  for (const item of heuristicas) {
+    if (!item) continue;
+
+    if (typeof item === "string") {
+      const flag = arquivoToFlag[normalizeKey(item)];
+      if (flag) {
+        result[flag] = true;
+      }
+      continue;
+    }
+
+    const candidates = collectCandidateStrings(item);
+    for (const candidate of candidates) {
+      const flag = arquivoToFlag[normalizeKey(candidate)];
+      if (flag) {
+        result[flag] = true;
+      }
+    }
+
+    const tags = collectTags(item);
+    for (const tag of tags) {
+      const flag = tagToFlag[normalizeKey(tag)];
+      if (flag) {
+        result[flag] = true;
+      }
+    }
+  }
+
+  return result;
+}
+

--- a/server/tests/promptContext/SelectorHeuristicas.test.ts
+++ b/server/tests/promptContext/SelectorHeuristicas.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Selector } from "../../services/promptContext/Selector";
+import { mapHeuristicasToFlags } from "../../services/promptContext/heuristicaFlags";
+
+test("inclui módulo de ancoragem quando heurística correspondente é detectada", () => {
+  const heuristicas = [
+    { arquivo: "eco_heuristica_ancoragem.txt", similarity: 0.91, tags: ["ancoragem"] },
+  ];
+
+  const heuristicaFlags = mapHeuristicasToFlags(heuristicas);
+  const flags = Selector.derivarFlags("Texto neutro sem pedido prático.", heuristicaFlags);
+  const resultado = Selector.selecionarModulosBase({
+    nivel: 2,
+    intensidade: 5,
+    flags,
+  });
+
+  assert.ok(
+    resultado.posGating.includes("eco_heuristica_ancoragem.txt"),
+    "deveria ativar o módulo de ancoragem"
+  );
+});
+
+test("inclui módulo de certeza emocional quando flag derivada por tags é verdadeira", () => {
+  const heuristicas = [
+    { id: "abc", tags: ["certeza_emocional", "conviccao_rapida"] },
+  ];
+
+  const heuristicaFlags = mapHeuristicasToFlags(heuristicas);
+  const flags = Selector.derivarFlags("Mensagem reflexiva sem pedidos.", heuristicaFlags);
+  const resultado = Selector.selecionarModulosBase({
+    nivel: 3,
+    intensidade: 6,
+    flags,
+  });
+
+  assert.ok(
+    resultado.posGating.includes("eco_heuristica_certeza_emocional.txt"),
+    "deveria ativar o módulo de certeza emocional"
+  );
+});
+


### PR DESCRIPTION
## Summary
- translate heuristic matches into boolean flags that feed Selector.selecionarModulosBase
- extend Selector flag derivation to accept heuristic-driven inputs so matrizPromptBaseV2 rules can trigger
- add focused tests that cover heuristic-driven module selection

## Testing
- npx ts-node server/tests/promptContext/SelectorHeuristicas.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d9bf4f921c83259cd65c9aeb152ec2