### PR TITLE
Delay Supabase initialization until routing decision

### DIFF
--- a/server/services/ConversationOrchestrator.ts
+++ b/server/services/ConversationOrchestrator.ts
@@ -53,7 +53,6 @@ export async function getEcoResponse(
   }
 
   const ultimaMsg = (messages as any).at(-1)?.content || "";
-  const supabase = supabaseWithBearer(accessToken);
 
   // Micro-resposta local
   const micro = microReflexoLocal(ultimaMsg);
@@ -92,6 +91,8 @@ export async function getEcoResponse(
       mode: decision.mode,
     });
   }
+
+  const supabase = supabaseWithBearer(accessToken);
 
   // --------------------------- FAST MODE ---------------------------
   if (decision.mode === "fast") {


### PR DESCRIPTION
## Summary
- move Supabase client creation in the conversation orchestrator so early exits avoid instantiating it
- ensure the fast and full branches still receive the Supabase client reference

## Testing
- TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' node -r ts-node/register/transpile-only /tmp/orchestrator_sim.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9c6ceb1f483258d02ff2cfc5a8f5e