### PR TITLE
Refine conversation thread typing

### DIFF
--- a/server/services/conversation/fastLane.ts
+++ b/server/services/conversation/fastLane.ts
@@ -1,4 +1,4 @@
-import { mapRoleForOpenAI, type GetEcoResult } from "../../utils";
+import { mapRoleForOpenAI, type ChatMessage, type GetEcoResult } from "../../utils";
 import { log } from "../promptContext/logger";
 import type { FinalizeParams } from "./responseFinalizer";
 
@@ -24,7 +24,7 @@ export interface RunFastLaneLLMDeps {
 }
 
 export interface RunFastLaneLLMParams {
-  messages: Array<{ role: string; content: string; id?: string }>;
+  messages: ChatMessage[];
   userName?: string;
   ultimaMsg: string;
   hasAssistantBefore: boolean;

--- a/server/services/conversation/greeting.ts
+++ b/server/services/conversation/greeting.ts
@@ -1,4 +1,4 @@
-import { mapRoleForOpenAI } from "../../utils";
+import { mapRoleForOpenAI, type ChatMessage } from "../../utils";
 import { GreetGuard } from "../../core/policies/GreetGuard";
 import {
   respostaSaudacaoAutomatica,
@@ -7,7 +7,7 @@ import {
 } from "../../utils/respostaSaudacaoAutomatica";
 
 export interface GreetingPipelineParams {
-  messages: Array<{ role: any; content: string }>;
+  messages: ChatMessage[];
   ultimaMsg: string;
   userId?: string;
   userName?: string;

--- a/server/services/conversation/promptPlan.ts
+++ b/server/services/conversation/promptPlan.ts
@@ -1,4 +1,4 @@
-import { mapRoleForOpenAI } from "../../utils";
+import { mapRoleForOpenAI, type ChatMessage } from "../../utils";
 import type { RouteDecision } from "./router";
 
 type PromptMessage = { role: "system" | "user" | "assistant"; content: string };
@@ -21,7 +21,7 @@ export interface BuildFullPromptParams {
   decision: RouteDecision;
   ultimaMsg: string;
   systemPrompt: string;
-  messages: Array<{ role: any; content: string }>;
+  messages: ChatMessage[];
   historyLimit?: number;
 }
 

--- a/server/services/conversation/router.ts
+++ b/server/services/conversation/router.ts
@@ -1,9 +1,9 @@
-import { mapRoleForOpenAI } from "../../utils";
+import { mapRoleForOpenAI, type ChatMessage } from "../../utils";
 import { derivarNivel, detectarSaudacaoBreve } from "../promptContext/Selector";
 import { heuristicaPreViva, isLowComplexity } from "./helpers";
 
 export interface RouteDecisionParams {
-  messages: Array<{ role: any; content: string }>;
+  messages: ChatMessage[];
   ultimaMsg: string;
   forcarMetodoViva?: boolean;
   promptOverride?: string | null;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2021"],
+    "lib": ["es2022"],
     "rootDir": "./",
     "outDir": "./dist",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- reuse a typed `thread` in the conversation orchestrator and share the last message metadata with fast and full responses
- update conversation helper modules to accept `ChatMessage[]` inputs without casts
- bump the server TypeScript target/lib to ES2022 so the stricter typing still supports modern helpers such as `Array.at`

## Testing
- npx tsc --noEmit -p server/tsconfig.json *(fails: missing third-party type declarations already absent in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c9c67bc08325ab10e82b7cdfb619