### PR TITLE
Handle embedding fetch failures gracefully

### DIFF
--- a/server/services/conversation/parallelFetch.ts
+++ b/server/services/conversation/parallelFetch.ts
@@ -38,7 +38,14 @@ export class ParallelFetchService {
     let userEmbedding: number[] = [];
     const trimmed = (ultimaMsg || "").trim();
     if (trimmed.length > 0) {
-      userEmbedding = await this.deps.getEmbedding(trimmed, "entrada_usuario");
+      try {
+        userEmbedding = await this.deps.getEmbedding(trimmed, "entrada_usuario");
+      } catch (e: any) {
+        userEmbedding = [];
+        this.deps.logger.warn(
+          `[ParallelFetch] getEmbedding falhou: ${e?.message ?? "erro desconhecido"}`
+        );
+      }
     }
 
     let heuristicas: any[] = [];

--- a/server/tests/conversation/parallelFetch.test.ts
+++ b/server/tests/conversation/parallelFetch.test.ts
@@ -9,34 +9,56 @@ const { ParallelFetchService } = require("../../services/conversation/parallelFe
 
 const fakeEmbedding = [0.1, 0.2, 0.3];
 
-function createDeps() {
+type DepsOverrides = {
+  getEmbedding?: (texto: string, tipo: string) => Promise<number[]>;
+  getHeuristicas?: (params: any) => Promise<any[]>;
+  getMemorias?: (userId: string, params: any) => Promise<any[]>;
+  debug?: () => boolean;
+  logger?: { warn: (msg: string) => void };
+};
+
+function createDeps(overrides: DepsOverrides = {}) {
   const calls: Record<string, unknown[]> = {
     getEmbedding: [],
     getHeuristicas: [],
     getMemorias: [],
   };
 
+  const warnings: string[] = [];
+
   const deps = {
     getEmbedding: async (texto: string, tipo: string) => {
       calls.getEmbedding.push([texto, tipo]);
+      if (overrides.getEmbedding) {
+        return overrides.getEmbedding(texto, tipo);
+      }
       return fakeEmbedding;
     },
     getHeuristicas: async (params: any) => {
       calls.getHeuristicas.push(params);
+      if (overrides.getHeuristicas) {
+        return overrides.getHeuristicas(params);
+      }
       return ["heuristica"];
     },
     getMemorias: async (userId: string, params: any) => {
       calls.getMemorias.push([userId, params]);
+      if (overrides.getMemorias) {
+        return overrides.getMemorias(userId, params);
+      }
       return ["mem" as any];
     },
     logger: {
-      warn: () => undefined,
+      warn: (msg: string) => {
+        warnings.push(msg);
+        overrides.logger?.warn?.(msg);
+      },
     },
-    debug: () => true,
+    debug: overrides.debug ?? (() => true),
   } as const;
 
   const service = new ParallelFetchService(deps as any);
-  return { service, calls };
+  return { service, calls, warnings };
 }
 
 test("gera embedding apenas quando há mensagem relevante", async () => {
@@ -87,5 +109,25 @@ test("ignora busca de memórias quando usuário indefinido", async () => {
 
   assert.deepStrictEqual(res.memsSemelhantes, []);
   assert.strictEqual(calls.getMemorias.length, 0);
+});
+
+test("continua execução com embedding vazio quando getEmbedding falha", async () => {
+  const { service, calls, warnings } = createDeps({
+    getEmbedding: async () => {
+      throw new Error("embedding indisponível");
+    },
+  });
+
+  const res = await service.run({ ultimaMsg: "preciso de ajuda", userId: "user" });
+
+  assert.deepStrictEqual(res, {
+    heuristicas: [],
+    memsSemelhantes: [],
+    userEmbedding: [],
+  } satisfies ParallelFetchResult);
+  assert.strictEqual(calls.getHeuristicas.length, 0);
+  assert.strictEqual(calls.getMemorias.length, 0);
+  assert.strictEqual(warnings.length, 1);
+  assert.match(warnings[0], /getEmbedding falhou: embedding indisponível/);
 });
 


### PR DESCRIPTION
## Summary
- wrap getEmbedding with a warning fallback so downstream heuristics and memory searches only run with a valid embedding
- extend parallelFetch tests with override helpers and a failure scenario to verify the new behavior

## Testing
- node --require ts-node/register --test server/tests/conversation/parallelFetch.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9ce6317f48325a6ddaa5ea517d6df