### PR TITLE
Prevent duplicate greetings after assistant response

### DIFF
--- a/server/tests/conversation/greetingPipeline.test.ts
+++ b/server/tests/conversation/greetingPipeline.test.ts
@@ -59,3 +59,22 @@ test("não envia saudação quando há conteúdo substantivo", () => {
   assert.deepStrictEqual(result, { handled: false });
   assert.deepStrictEqual(marks, []);
 });
+
+test("não repete saudação automática quando assistente já respondeu", () => {
+  const { pipeline, marks } = createPipeline();
+
+  const history = [
+    { role: "assistant", content: "Olá! Como posso ajudar hoje?" },
+    { role: "user", content: "Oi" },
+  ];
+
+  const result = pipeline.handle({
+    messages: history,
+    ultimaMsg: "Oi",
+    greetingEnabled: true,
+    userId: "user-789",
+  });
+
+  assert.deepStrictEqual(result, { handled: false });
+  assert.deepStrictEqual(marks, []);
+});

--- a/server/tests/conversation/responseFinalizer.test.ts
+++ b/server/tests/conversation/responseFinalizer.test.ts
@@ -23,7 +23,9 @@ Module._load = function patchedLoad(request: string, parent: any, isMain: boolea
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const responseFinalizerModule = require("../../services/conversation/responseFinalizer") as typeof import("../../services/conversation/responseFinalizer");
+const helpersModule = require("../../services/conversation/helpers") as typeof import("../../services/conversation/helpers");
 const { ResponseFinalizer } = responseFinalizerModule;
+const { stripRedundantGreeting } = helpersModule;
 Module._load = originalLoad;
 
 const noop = () => {};
@@ -109,4 +111,19 @@ test("preenche intensidade e resumo quando bloco chega dentro do timeout", async
 
   assert.strictEqual(result.intensidade, 0.42);
   assert.strictEqual(result.resumo, "resumo alinhado");
+});
+
+test("stripRedundantGreeting remove saudação quando assistente já respondeu", () => {
+  const casos: Array<[string, string]> = [
+    ["Oi, tudo bem?", "tudo bem?"],
+    ["Boa noite! Como posso ajudar?", "Como posso ajudar?"],
+  ];
+
+  for (const [input, esperado] of casos) {
+    const resultado = stripRedundantGreeting(input, true);
+    assert.strictEqual(resultado, esperado);
+  }
+
+  const semAssistente = stripRedundantGreeting("Oi, tudo bem?", false);
+  assert.strictEqual(semAssistente, "Oi, tudo bem?");
 });

--- a/server/utils/text.ts
+++ b/server/utils/text.ts
@@ -17,8 +17,15 @@ export function ensureEnvs() {
 // -----------------------------
 export const mapRoleForOpenAI = (
   role: string,
-): "user" | "assistant" | "system" =>
-  role === "model" ? "assistant" : role === "system" ? "system" : "user";
+): "user" | "assistant" | "system" => {
+  if (role === "assistant" || role === "model") {
+    return "assistant";
+  }
+  if (role === "system") {
+    return "system";
+  }
+  return "user";
+};
 
 // -----------------------------
 // Sanitização & formatação


### PR DESCRIPTION
## Summary
- map assistant/model roles to assistant when preparing OpenAI payloads
- prevent greeting pipeline from re-sending automated greeting when assistant already spoke
- cover redundant greeting stripping when a previous assistant reply exists

## Testing
- NODE_OPTIONS='--require ts-node/register' node --test server/tests/**/*.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9da3532a883259291e8dbf0935369