### PR TITLE
Add English aliases for memory routes

### DIFF
--- a/server/core/http/app.ts
+++ b/server/core/http/app.ts
@@ -42,6 +42,7 @@ export function createApp(): Express {
 
   app.use("/api", promptRoutes);
   app.use("/api/memorias", memoryRoutes);
+  app.use("/api/memories", memoryRoutes);
   app.use("/api/perfil-emocional", profileRoutes);
   app.use("/api/voice", voiceTTSRoutes);
   app.use("/api/voice", voiceFullRoutes);
@@ -50,6 +51,7 @@ export function createApp(): Express {
   app.use("/api/feedback", feedbackRoutes);
 
   app.use("/memorias", memoryRoutes);
+  app.use("/memories", memoryRoutes);
   app.use("/perfil-emocional", profileRoutes);
   app.use("/relatorio-emocional", relatorioRoutes);
 

--- a/server/domains/memory/routes.ts
+++ b/server/domains/memory/routes.ts
@@ -8,4 +8,7 @@ router.post("/registrar", controller.registerMemory);
 router.get("/", controller.listMemories);
 router.post("/similares", controller.findSimilar);
 
+router.post("/similares_v2", controller.findSimilar);
+router.post("/similar_v2", controller.findSimilar);
+
 export default router;


### PR DESCRIPTION
## Summary
- add additional memory router endpoints that reuse the existing similar-memory controller
- mount the memory routes on English aliases under /api/memories and /memories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9df88f1648325a01c2a23f707f3cd