### PR TITLE
Add v1 aliases for emotional profile and report routes

### DIFF
--- a/server/core/http/app.ts
+++ b/server/core/http/app.ts
@@ -44,10 +44,12 @@ export function createApp(): Express {
   app.use("/api/memorias", memoryRoutes);
   app.use("/api/memories", memoryRoutes);
   app.use("/api/perfil-emocional", profileRoutes);
+  app.use("/api/v1/perfil-emocional", profileRoutes);
   app.use("/api/voice", voiceTTSRoutes);
   app.use("/api/voice", voiceFullRoutes);
   app.use("/api", openrouterRoutes);
   app.use("/api/relatorio-emocional", relatorioRoutes);
+  app.use("/api/v1/relatorio-emocional", relatorioRoutes);
   app.use("/api/feedback", feedbackRoutes);
 
   app.use("/memorias", memoryRoutes);


### PR DESCRIPTION
## Summary
- expose the emotional profile and report routes under versioned /api/v1 prefixes while retaining the existing paths
- verify other mounted domains already have either bilingual aliases or do not yet require versioning

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d9e1ad3d2c8325b370ec22f3f39b55