### PR TITLE
Propagate Mixpanel distinct IDs through session metadata

### DIFF
--- a/server/analytics/events/mixpanelEvents.ts
+++ b/server/analytics/events/mixpanelEvents.ts
@@ -1,103 +1,147 @@
 // server/events/mixpanelEvents.ts
 import mixpanel from '../../lib/mixpanel';
 
+type BaseProps = { distinctId?: string; userId?: string };
+
+type TrackParams<T extends Record<string, unknown>> = BaseProps & T;
+
+const withDistinctId = <T extends Record<string, unknown>>(
+  props: TrackParams<T>
+): Record<string, unknown> => {
+  const { distinctId, userId, ...rest } = props;
+  const trackId = distinctId || userId;
+  return {
+    ...(trackId ? { distinct_id: trackId } : {}),
+    ...(userId ? { userId } : {}),
+    ...rest,
+  };
+};
+
+export const identifyUsuario = ({
+  distinctId,
+  userId,
+  versaoApp,
+  device,
+  ambiente,
+}: {
+  distinctId?: string;
+  userId?: string;
+  versaoApp?: string | null;
+  device?: string | null;
+  ambiente?: string | null;
+}): void => {
+  if (!distinctId) return;
+
+  const props: Record<string, unknown> = {};
+  if (userId) props.user_id = userId;
+  if (versaoApp !== undefined) props.versao_app = versaoApp;
+  if (device !== undefined) props.device = device;
+  if (ambiente !== undefined) props.ambiente = ambiente;
+
+  if (Object.keys(props).length === 0) return;
+
+  mixpanel.people.set_once(distinctId, props);
+};
+
 export const trackMensagemEnviada = ({
+  distinctId,
   userId,
   tempoRespostaMs,
   tokensUsados,
   modelo,
-}: {
-  userId?: string;
+}: TrackParams<{
   tempoRespostaMs?: number;
   tokensUsados?: number;
   modelo?: string;
-}) => {
-  mixpanel.track('Mensagem enviada', {
-    userId,
-    tempoRespostaMs,
-    tokensUsados,
-    modelo,
-  });
+}>) => {
+  mixpanel.track(
+    'Mensagem enviada',
+    withDistinctId({ distinctId, userId, tempoRespostaMs, tokensUsados, modelo })
+  );
 };
 
 export const trackEcoDemorou = ({
+  distinctId,
   userId,
   duracaoMs,
   ultimaMsg,
-}: {
-  userId?: string;
+}: TrackParams<{
   duracaoMs: number;
   ultimaMsg: string;
-}) => {
-  mixpanel.track('Eco demorou', {
-    userId,
-    duracaoMs,
-    ultimaMsg,
-  });
+}>) => {
+  mixpanel.track(
+    'Eco demorou',
+    withDistinctId({ distinctId, userId, duracaoMs, ultimaMsg })
+  );
 };
 
 export const trackPerguntaProfunda = ({
+  distinctId,
   userId,
   emocao,
   intensidade,
   categoria,
   dominioVida,
-}: {
-  userId?: string;
+}: TrackParams<{
   emocao: string;
   intensidade?: number;
   categoria?: string | null;
   dominioVida?: string | null;
-}) => {
-  mixpanel.track('Pergunta profunda feita', {
-    userId,
-    emocao,
-    intensidade,
-    categoria,
-    dominioVida,
-  });
+}>) => {
+  mixpanel.track(
+    'Pergunta profunda feita',
+    withDistinctId({
+      distinctId,
+      userId,
+      emocao,
+      intensidade,
+      categoria,
+      dominioVida,
+    })
+  );
 };
 
 export const trackMemoriaRegistrada = ({
+  distinctId,
   userId,
   intensidade,
   emocao,
   categoria,
   dominioVida,
-}: {
-  userId?: string;
+}: TrackParams<{
   intensidade?: number;
   emocao: string;
   categoria?: string | null;
   dominioVida?: string | null;
-}) => {
-  mixpanel.track('Memória registrada', {
-    userId,
-    intensidade,
-    emocao,
-    categoria,
-    dominioVida,
-  });
+}>) => {
+  mixpanel.track(
+    'Memória registrada',
+    withDistinctId({
+      distinctId,
+      userId,
+      intensidade,
+      emocao,
+      categoria,
+      dominioVida,
+    })
+  );
 };
 
 export const trackReferenciaEmocional = ({
+  distinctId,
   userId,
   intensidade,
   emocao,
   tags,
   categoria,
-}: {
-  userId?: string;
+}: TrackParams<{
   intensidade?: number;
   emocao: string;
   tags: string[];
   categoria?: string | null;
-}) => {
-  mixpanel.track('Referência emocional', {
-    userId,
-    intensidade,
-    emocao,
-    tags,
-    categoria,
-  });
+}>) => {
+  mixpanel.track(
+    'Referência emocional',
+    withDistinctId({ distinctId, userId, intensidade, emocao, tags, categoria })
+  );
 };

--- a/server/routes/openrouterRoutes.ts
+++ b/server/routes/openrouterRoutes.ts
@@ -5,6 +5,7 @@ import { supabase } from "../lib/supabaseAdmin"; // ✅ usa a instância (não �
 import { getEcoResponse } from "../services/ConversationOrchestrator";
 import { embedTextoCompleto } from "../adapters/embeddingService";
 import { buscarMemoriasSemelhantes } from "../services/buscarMemorias";
+import { extractSessionMeta } from "./sessionMeta";
 
 // montar contexto e log
 import { ContextBuilder } from "../services/promptContext";
@@ -113,6 +114,8 @@ router.post("/ask-eco", async (req: Request, res: Response) => {
     }
 
     // orquestrador (usa promptOverride)
+    const sessionMeta = extractSessionMeta(req.body);
+
     const resposta = await getEcoResponse({
       messages: mensagensParaIA,
       userId: usuario_id,
@@ -120,6 +123,7 @@ router.post("/ask-eco", async (req: Request, res: Response) => {
       accessToken: token,
       mems: memsSimilares,
       promptOverride: prompt, // <- string
+      sessionMeta,
     } as any); // se o tipo ainda não tiver promptOverride
 
     return res.status(200).json(resposta);

--- a/server/routes/sessionMeta.ts
+++ b/server/routes/sessionMeta.ts
@@ -1,0 +1,81 @@
+import type { SessionMetadata } from "../utils";
+
+type AnyRecord = Record<string, unknown>;
+
+const pickString = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+};
+
+const pickNullableString = (...values: unknown[]): string | null | undefined => {
+  const picked = pickString(...values);
+  return picked ?? undefined;
+};
+
+const possibleContainers = [
+  "sessionMeta",
+  "session_meta",
+  "session",
+  "sessaoMeta",
+  "sessao_meta",
+  "sessao",
+  "metaSessao",
+  "meta_sessao",
+  "metadadosSessao",
+  "metadados_sessao",
+  "metadata",
+];
+
+export function extractSessionMeta(payload: AnyRecord | null | undefined): SessionMetadata | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+
+  let container: AnyRecord | undefined;
+  for (const key of possibleContainers) {
+    const value = (payload as AnyRecord)[key];
+    if (value && typeof value === "object") {
+      container = value as AnyRecord;
+      break;
+    }
+  }
+
+  const source = container ?? payload;
+
+  const distinctId = pickString(
+    (source as AnyRecord).distinctId,
+    (source as AnyRecord).distinct_id,
+    (source as AnyRecord).distinctID,
+    (source as AnyRecord).mpDistinctId,
+    (payload as AnyRecord).distinctId,
+    (payload as AnyRecord).distinct_id
+  );
+
+  const versaoApp = pickNullableString(
+    (source as AnyRecord).versaoApp,
+    (source as AnyRecord).versao_app,
+    (source as AnyRecord).appVersion
+  );
+  const device = pickNullableString(
+    (source as AnyRecord).device,
+    (source as AnyRecord).dispositivo,
+    (source as AnyRecord).device_name
+  );
+  const ambiente = pickNullableString(
+    (source as AnyRecord).ambiente,
+    (source as AnyRecord).environment,
+    (source as AnyRecord).env
+  );
+
+  const hasAny = distinctId || versaoApp || device || ambiente;
+  if (!hasAny) return undefined;
+
+  return {
+    distinctId,
+    versaoApp: versaoApp ?? null,
+    device: device ?? null,
+    ambiente: ambiente ?? null,
+  } as SessionMetadata;
+}

--- a/server/routes/voiceFullRoutes.ts
+++ b/server/routes/voiceFullRoutes.ts
@@ -3,6 +3,7 @@ import multer from "multer";
 import { generateAudio } from "../services/elevenlabsService";
 import { getEcoResponse } from "../services/ConversationOrchestrator";
 import { transcribeWithWhisper } from "../scripts/transcribe";
+import { extractSessionMeta } from "./sessionMeta";
 
 const router = express.Router();
 
@@ -77,10 +78,13 @@ router.post("/transcribe-and-respond", (req: Request, res: Response, next: NextF
       msgs = [{ role: "user", content: userText }];
     }
 
+    const sessionMeta = extractSessionMeta(req.body);
+
     const eco = await getEcoResponse({
       messages: msgs,
       userId: usuario_id || "anon",
       accessToken: access_token,
+      sessionMeta,
     });
 
     const ecoText = (eco?.message || "").trim();

--- a/server/services/ConversationOrchestrator.ts
+++ b/server/services/ConversationOrchestrator.ts
@@ -45,6 +45,7 @@ export async function getEcoResponse(
     clientHour,
     promptOverride,
     metaFromBuilder,
+    sessionMeta,
   }: GetEcoParams & { promptOverride?: string; metaFromBuilder?: any }
 ): Promise<GetEcoResult> {
   ensureEnvs();
@@ -115,6 +116,7 @@ export async function getEcoResponse(
         responseFinalizer: defaultResponseFinalizer,
         firstName,
       },
+      sessionMeta,
     });
 
     return fast.response;
@@ -286,6 +288,7 @@ export async function getEcoResponse(
       usageTokens: undefined,
       modelo: "full-fallback",
       skipBloco: true,
+      sessionMeta,
     });
   }
 
@@ -308,6 +311,7 @@ export async function getEcoResponse(
     startedAt: inicioEco,
     usageTokens: data?.usage?.total_tokens ?? undefined,
     modelo: data?.model,
+    sessionMeta,
   });
 }
 

--- a/server/services/conversation/fastLane.ts
+++ b/server/services/conversation/fastLane.ts
@@ -1,4 +1,9 @@
-import { mapRoleForOpenAI, type ChatMessage, type GetEcoResult } from "../../utils";
+import {
+  mapRoleForOpenAI,
+  type ChatMessage,
+  type GetEcoResult,
+  type SessionMetadata,
+} from "../../utils";
 import { log } from "../promptContext/logger";
 import type { FinalizeParams } from "./responseFinalizer";
 
@@ -33,6 +38,7 @@ export interface RunFastLaneLLMParams {
   lastMessageId?: string;
   startedAt: number;
   deps: RunFastLaneLLMDeps;
+  sessionMeta?: SessionMetadata;
 }
 
 export interface RunFastLaneLLMResult {
@@ -103,6 +109,7 @@ export async function runFastLaneLLM({
   lastMessageId,
   startedAt,
   deps,
+  sessionMeta,
 }: RunFastLaneLLMParams): Promise<RunFastLaneLLMResult> {
   const nome = deps.firstName?.(userName);
   const preferCoach = detectExplicitAskForSteps(ultimaMsg);
@@ -134,6 +141,7 @@ export async function runFastLaneLLM({
       startedAt,
       usageTokens: undefined,
       modelo: "fastlane-fallback",
+      sessionMeta,
     });
 
     return { raw: fallback, usage: null, model: "fastlane-fallback", response };
@@ -155,6 +163,7 @@ export async function runFastLaneLLM({
     startedAt,
     usageTokens: usage?.total_tokens ?? undefined,
     modelo: model,
+    sessionMeta,
   });
 
   return { raw, usage, model, response };

--- a/server/tests/conversation/fastLane.test.ts
+++ b/server/tests/conversation/fastLane.test.ts
@@ -74,6 +74,7 @@ test("runFastLaneLLM envia apenas as 3 últimas mensagens do histórico", async 
     lastMessageId: "msg-5",
     startedAt: 1000,
     deps,
+    sessionMeta: { distinctId: "distinct-xyz" },
   })) as RunFastLaneLLMResult;
 
   assert.strictEqual(claudeCalls.length, 1);
@@ -94,6 +95,11 @@ test("runFastLaneLLM envia apenas as 3 últimas mensagens do histórico", async 
   assert.strictEqual(finalizeCalls[0].usageTokens, 42);
   assert.strictEqual(finalizeCalls[0].modelo, "test-model");
   assert.strictEqual(finalizeCalls[0].mode, "fast");
+  assert.strictEqual(
+    finalizeCalls[0].sessionMeta?.distinctId,
+    "distinct-xyz",
+    "finalize recebe sessionMeta"
+  );
 });
 
 test("runFastLaneLLM usa fallback quando o cliente Claude falha", async () => {
@@ -122,6 +128,7 @@ test("runFastLaneLLM usa fallback quando o cliente Claude falha", async () => {
     lastMessageId: undefined,
     startedAt: 123,
     deps,
+    sessionMeta: { distinctId: "fallback-1" },
   });
 
   assert.strictEqual(result.raw, "Tô aqui com você. Quer me contar um pouco mais?");

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -11,5 +11,5 @@ export {
 
 export type {
   AnyRecord, ChatMessage, ParalelasResult, TrendPack, ProactivePayload,
-  GetEcoParams, GetEcoResult, Memoria, Heuristica, NivelNum
+  GetEcoParams, GetEcoResult, Memoria, Heuristica, NivelNum, SessionMetadata
 } from "./types";

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -30,6 +30,7 @@ export type GetEcoParams = {
   forcarMetodoViva?: boolean;
   blocoTecnicoForcado?: any;
   clientHour?: number;
+  sessionMeta?: SessionMetadata;
 };
 
 export type GetEcoResult = {
@@ -61,3 +62,10 @@ export interface Heuristica {
   arquivo: string;
   gatilhos: string[];
 }
+
+export type SessionMetadata = {
+  distinctId?: string;
+  versaoApp?: string | null;
+  device?: string | null;
+  ambiente?: string | null;
+};


### PR DESCRIPTION
## Summary
- add an identify helper and include `distinct_id` on Mixpanel events
- propagate session metadata from the routes through the orchestrator into the response finalizer
- update tests and add a session metadata extractor to exercise the new flow

## Testing
- node --require ts-node/register --test server/tests/conversation/responseFinalizer.test.ts server/tests/conversation/fastLane.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc0517827c8325b30e8d1d4dbb8673