### PR TITLE
Add analytics tracking for bloco técnico generation

### DIFF
--- a/server/analytics/events/mixpanelEvents.ts
+++ b/server/analytics/events/mixpanelEvents.ts
@@ -145,3 +145,35 @@ export const trackReferenciaEmocional = ({
     withDistinctId({ distinctId, userId, intensidade, emocao, tags, categoria })
   );
 };
+
+export const trackBlocoTecnico = ({
+  distinctId,
+  userId,
+  status,
+  mode,
+  skipBloco,
+  duracaoMs,
+  intensidade,
+  erro,
+}: TrackParams<{
+  status: 'success' | 'failure' | 'timeout';
+  mode: 'fast' | 'full';
+  skipBloco: boolean;
+  duracaoMs?: number;
+  intensidade?: number | null;
+  erro?: string;
+}>) => {
+  mixpanel.track(
+    'Bloco técnico',
+    withDistinctId({
+      distinctId,
+      userId,
+      status,
+      mode,
+      skipBloco,
+      ...(duracaoMs !== undefined ? { duracaoMs } : {}),
+      ...(intensidade !== undefined ? { intensidade } : {}),
+      ...(erro ? { erro } : {}),
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- add a Mixpanel helper to track bloco técnico generation outcomes with relevant metadata
- emit success, timeout, and failure events from the response finalizer using the helper
- propagate distinct identifiers into the finalizer and log reprocess failures with error details

## Testing
- npm test -- --runInBand *(fails: Missing script "test")*
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dc079f6bec8325bcae4492de5dd5d2