### PR TITLE
Add Mixpanel tracking for relatório emocional views

### DIFF
--- a/docs/relatorio-emocional-endpoint.md
+++ b/docs/relatorio-emocional-endpoint.md
@@ -1,0 +1,11 @@
+# Relatório emocional - contrato de API
+
+As rotas montadas em `/api/relatorio-emocional`, `/api/v1/relatorio-emocional` e `/relatorio-emocional` continuam aceitando as mesmas formas de identificação do usuário, mas agora expõem um parâmetro opcional de visualização.
+
+## Parâmetro `view`
+
+- **Onde enviar**: query string (`?view=...`) ou header HTTP (`view`, `x-relatorio-view` ou `x-relatorio-emocional-view`).
+- **Valores aceitos**: `mapa` (padrão) ou `linha_do_tempo`.
+- **Comportamento**: quando ausente ou inválido, a API assume automaticamente `mapa`, garantindo compatibilidade com clientes antigos.
+
+Essa informação também é registrada em Mixpanel através do evento `Relatório emocional acessado`, junto com o `distinctId` (quando fornecido) e a origem da chamada.

--- a/server/analytics/events/mixpanelEvents.ts
+++ b/server/analytics/events/mixpanelEvents.ts
@@ -177,3 +177,23 @@ export const trackBlocoTecnico = ({
     })
   );
 };
+
+export const trackRelatorioEmocionalAcessado = ({
+  distinctId,
+  userId,
+  origem,
+  view,
+}: TrackParams<{
+  origem: string;
+  view?: string | null;
+}>) => {
+  mixpanel.track(
+    'Relatório emocional acessado',
+    withDistinctId({
+      distinctId,
+      userId,
+      origem,
+      ...(view ? { view } : {}),
+    })
+  );
+};

--- a/server/routes/relatorioEmocionalRoutes.ts
+++ b/server/routes/relatorioEmocionalRoutes.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from "express";
+import { trackRelatorioEmocionalAcessado } from "../analytics/events/mixpanelEvents";
 import { gerarRelatorioEmocional } from "../utils/relatorioEmocionalUtils";
+import { extractDistinctId, extractRelatorioView } from "./relatorioEmocionalView";
 
 const router = Router();
 
@@ -43,6 +45,15 @@ router.get("/", async (req: Request, res: Response) => {
     }
 
     const relatorio = await gerarRelatorioEmocional(userId);
+    const view = extractRelatorioView(req);
+    const originPath = req.originalUrl ? req.originalUrl.split("?")[0] : req.path;
+
+    trackRelatorioEmocionalAcessado({
+      distinctId: extractDistinctId(req),
+      userId,
+      origem: `GET ${originPath}`,
+      view,
+    });
 
     return res.status(200).json({
       success: true,
@@ -67,6 +78,15 @@ router.get("/:usuario_id", async (req: Request, res: Response) => {
     }
 
     const relatorio = await gerarRelatorioEmocional(usuario_id);
+    const view = extractRelatorioView(req);
+    const originPath = req.originalUrl ? req.originalUrl.split("?")[0] : req.path;
+
+    trackRelatorioEmocionalAcessado({
+      distinctId: extractDistinctId(req),
+      userId: usuario_id,
+      origem: `GET ${originPath}`,
+      view,
+    });
 
     return res.status(200).json({
       success: true,

--- a/server/routes/relatorioEmocionalView.ts
+++ b/server/routes/relatorioEmocionalView.ts
@@ -1,0 +1,67 @@
+import type { Request } from "express";
+
+const RELATORIO_VIEWS = ["mapa", "linha_do_tempo"] as const;
+export type RelatorioView = (typeof RELATORIO_VIEWS)[number];
+const VALID_VIEWS = new Set<string>(RELATORIO_VIEWS);
+export const DEFAULT_RELATORIO_VIEW: RelatorioView = "mapa";
+
+const POSSIBLE_VIEW_HEADER_KEYS = [
+  "x-relatorio-view",
+  "x-relatorio-emocional-view",
+  "x-view",
+  "view",
+] as const;
+
+const POSSIBLE_DISTINCT_ID_QUERY_KEYS = ["distinctId", "distinct_id", "distinctID"] as const;
+const POSSIBLE_DISTINCT_ID_HEADER_KEYS = [
+  "x-mixpanel-distinct-id",
+  "x-mp-distinct-id",
+  "distinct-id",
+  "distinctid",
+  "distinct",
+] as const;
+
+const pickFirstString = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const [first] = value;
+    if (typeof first === "string") return first;
+  }
+  return undefined;
+};
+
+export const extractRelatorioView = (req: Request): RelatorioView => {
+  const queryValue = pickFirstString(req.query?.view);
+  const normalizedQuery = queryValue?.trim().toLowerCase();
+  if (normalizedQuery && VALID_VIEWS.has(normalizedQuery)) {
+    return normalizedQuery as RelatorioView;
+  }
+
+  for (const key of POSSIBLE_VIEW_HEADER_KEYS) {
+    const headerValue = pickFirstString(req.headers[key]);
+    const normalized = headerValue?.trim().toLowerCase();
+    if (normalized && VALID_VIEWS.has(normalized)) {
+      return normalized as RelatorioView;
+    }
+  }
+
+  return DEFAULT_RELATORIO_VIEW;
+};
+
+export const extractDistinctId = (req: Request): string | undefined => {
+  for (const key of POSSIBLE_DISTINCT_ID_QUERY_KEYS) {
+    const candidate = pickFirstString((req.query as Record<string, unknown> | undefined)?.[key]);
+    if (candidate && candidate.trim()) return candidate.trim();
+  }
+
+  for (const key of POSSIBLE_DISTINCT_ID_HEADER_KEYS) {
+    const candidate = pickFirstString(req.headers[key]);
+    if (candidate && candidate.trim()) return candidate.trim();
+  }
+
+  return undefined;
+};
+
+export const __internal = {
+  pickFirstString,
+};

--- a/tests/relatorioEmocionalRoutes.test.ts
+++ b/tests/relatorioEmocionalRoutes.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import type { Request } from "express";
+import {
+  DEFAULT_RELATORIO_VIEW,
+  extractDistinctId,
+  extractRelatorioView,
+} from "../server/routes/relatorioEmocionalView";
+
+type TestCase = { name: string; run: () => Promise<void> | void };
+
+const tests: TestCase[] = [];
+
+function test(name: string, run: () => Promise<void> | void) {
+  tests.push({ name, run });
+}
+
+function makeRequest(overrides: Partial<Request>): Request {
+  return {
+    query: {},
+    headers: {},
+    ...overrides,
+  } as Request;
+}
+
+test("defaults to mapa when no view provided", () => {
+  const req = makeRequest({});
+  const view = extractRelatorioView(req);
+  assert.equal(view, DEFAULT_RELATORIO_VIEW);
+});
+
+test("accepts query parameter for view", () => {
+  const req = makeRequest({ query: { view: "linha_do_tempo" } as any });
+  const view = extractRelatorioView(req);
+  assert.equal(view, "linha_do_tempo");
+});
+
+test("accepts header parameter for view and normalizes case", () => {
+  const req = makeRequest({ headers: { "x-relatorio-view": "Mapa" } });
+  const view = extractRelatorioView(req);
+  assert.equal(view, "mapa");
+});
+
+test("extractDistinctId inspects query and headers", () => {
+  const reqWithQuery = makeRequest({ query: { distinct_id: " 123 " } as any });
+  assert.equal(extractDistinctId(reqWithQuery), "123");
+
+  const reqWithHeader = makeRequest({ headers: { "x-mixpanel-distinct-id": "abc" } });
+  assert.equal(extractDistinctId(reqWithHeader), "abc");
+});
+
+(async () => {
+  let failures = 0;
+  for (const { name, run } of tests) {
+    try {
+      await run();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      failures += 1;
+      console.error(`✗ ${name}`);
+      console.error(error);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`${failures} test(s) failed.`);
+    process.exitCode = 1;
+  } else {
+    console.log(`All ${tests.length} test(s) passed.`);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a Mixpanel helper to track accesses to the relatório emocional along with the requested view
- parse the optional `view` parameter from query or headers in the relatório emocional routes, defaulting to mapa
- document the new optional parameter and add tests for the view/distinctId extraction helpers

## Testing
- npx ts-node --compiler-options '{"module":"commonjs"}' tests/relatorioEmocionalRoutes.test.ts
- npx ts-node --compiler-options '{"module":"commonjs"}' tests/contextCache.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc0a6faf208325b18f05934116bc70