### PR TITLE
Log Mixpanel analytics for received messages

### DIFF
--- a/server/analytics/events/mixpanelEvents.ts
+++ b/server/analytics/events/mixpanelEvents.ts
@@ -61,6 +61,67 @@ export const trackMensagemEnviada = ({
   );
 };
 
+const toIsoTimestamp = (value: Date | string | number | undefined): string | undefined => {
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isNaN(ms) ? undefined : value.toISOString();
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+
+  if (typeof value === 'number') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+
+  return undefined;
+};
+
+export const trackMensagemRecebida = ({
+  distinctId,
+  userId,
+  origem,
+  tipo,
+  tamanhoCaracteres,
+  tamanhoBytes,
+  duracaoMs,
+  timestamp,
+  sessaoId,
+  origemSessao,
+}: TrackParams<{
+  origem: 'texto' | 'voz';
+  tipo?: 'inicial' | 'continuacao';
+  tamanhoCaracteres?: number;
+  tamanhoBytes?: number;
+  duracaoMs?: number;
+  timestamp: Date | string | number;
+  sessaoId?: string | null;
+  origemSessao?: string | null;
+}>) => {
+  const isoTimestamp = toIsoTimestamp(timestamp);
+
+  mixpanel.track(
+    'Mensagem recebida',
+    withDistinctId({
+      distinctId,
+      userId,
+      origem,
+      tipo,
+      ...(typeof tamanhoCaracteres === 'number'
+        ? { tamanhoCaracteres }
+        : {}),
+      ...(typeof tamanhoBytes === 'number' ? { tamanhoBytes } : {}),
+      ...(typeof duracaoMs === 'number' ? { duracaoMs } : {}),
+      ...(isoTimestamp ? { timestamp: isoTimestamp } : {}),
+      ...(sessaoId !== undefined ? { sessaoId } : {}),
+      ...(origemSessao !== undefined ? { origemSessao } : {}),
+    })
+  );
+};
+
 export const trackEcoDemorou = ({
   distinctId,
   userId,

--- a/server/tests/routes/mensagemRecebidaAnalytics.test.ts
+++ b/server/tests/routes/mensagemRecebidaAnalytics.test.ts
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const Module = require("node:module");
+
+type StubMap = Record<string, unknown>;
+
+type Loader<T> = () => Promise<T> | T;
+
+const withPatchedModules = async <T>(stubs: StubMap, loader: Loader<T>): Promise<T> => {
+  const originalLoad = Module._load;
+  Module._load = function patched(request: string, parent: any, isMain: boolean) {
+    if (Object.prototype.hasOwnProperty.call(stubs, request)) {
+      return stubs[request];
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    return await loader();
+  } finally {
+    Module._load = originalLoad;
+  }
+};
+
+const loadRouterWithStubs = async (modulePath: string, stubs: StubMap) => {
+  return withPatchedModules(stubs, () => {
+    const resolved = require.resolve(modulePath);
+    delete require.cache[resolved];
+    const mod = require(modulePath);
+    return mod.default ?? mod;
+  });
+};
+
+const getRouteHandler = (router: any, path: string, index = 0) => {
+  const layer = router.stack.find((entry: any) => entry.route?.path === path);
+  if (!layer) throw new Error(`Route ${path} not found`);
+  const stackEntry = layer.route.stack[index];
+  if (!stackEntry) throw new Error(`Handler ${index} for route ${path} not found`);
+  return stackEntry.handle;
+};
+
+const makeResponse = () => {
+  return {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    payload: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      this.payload = data;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers.set(name.toLowerCase(), value);
+    },
+  };
+};
+
+test("/ask-eco dispara trackMensagemRecebida com metadados básicos", async () => {
+  const trackCalls: any[] = [];
+
+  const router = await loadRouterWithStubs("../../routes/openrouterRoutes", {
+    "../lib/supabaseAdmin": {
+      supabase: {
+        auth: {
+          getUser: async () => ({ data: { user: { id: "supabase-user" } }, error: null }),
+        },
+      },
+    },
+    "../services/ConversationOrchestrator": {
+      getEcoResponse: async () => ({ message: "eco" }),
+    },
+    "../adapters/embeddingService": {
+      embedTextoCompleto: async () => [],
+    },
+    "../services/buscarMemorias": {
+      buscarMemoriasSemelhantes: async () => [],
+    },
+    "../services/promptContext": {
+      ContextBuilder: {
+        build: async () => "prompt",
+      },
+    },
+    "../services/promptContext/logger": {
+      log: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      isDebug: () => false,
+    },
+    "../analytics/events/mixpanelEvents": {
+      trackMensagemRecebida: (payload: unknown) => {
+        trackCalls.push(payload);
+      },
+    },
+  });
+
+  const handler = getRouteHandler(router, "/ask-eco");
+  const res = makeResponse();
+  const req = {
+    body: {
+      usuario_id: "user-1",
+      messages: [{ role: "user", content: "Oi Eco" }],
+      sessionMeta: {
+        distinctId: "distinct-1",
+        sessaoId: "sessao-xyz",
+        origem: "app-mobile",
+      },
+    },
+    headers: {
+      authorization: "Bearer token-123",
+    },
+  } as any;
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(trackCalls.length, 1);
+
+  const event = trackCalls[0];
+  assert.equal(event.distinctId, "distinct-1");
+  assert.equal(event.userId, "user-1");
+  assert.equal(event.origem, "texto");
+  assert.equal(event.tipo, "inicial");
+  assert.equal(event.tamanhoCaracteres, "Oi Eco".length);
+  assert.equal(event.sessaoId, "sessao-xyz");
+  assert.equal(event.origemSessao, "app-mobile");
+  assert.ok(typeof event.timestamp === "string");
+  assert.ok(!Number.isNaN(Date.parse(event.timestamp)));
+});
+
+test("rota de voz dispara trackMensagemRecebida com bytes e duração", async () => {
+  const trackCalls: any[] = [];
+
+  const router = await loadRouterWithStubs("../../routes/voiceFullRoutes", {
+    multer: Object.assign(
+      (options: unknown) => ({
+        single: () => (_req: any, _res: any, next: any) => next(),
+      }),
+      { memoryStorage: () => ({}) }
+    ),
+    "../services/elevenlabsService": {
+      generateAudio: async () => Buffer.from("eco-audio"),
+    },
+    "../services/ConversationOrchestrator": {
+      getEcoResponse: async () => ({ message: "eco resposta" }),
+    },
+    "../scripts/transcribe": {
+      transcribeWithWhisper: async () => "fala transcrita",
+    },
+    "../analytics/events/mixpanelEvents": {
+      trackMensagemRecebida: (payload: unknown) => {
+        trackCalls.push(payload);
+      },
+    },
+  });
+
+  const handler = getRouteHandler(router, "/transcribe-and-respond", 1);
+  const res = makeResponse();
+  const req = {
+    body: {
+      usuario_id: "user-voz",
+      mensagens: JSON.stringify([
+        { role: "assistant", content: "oi" },
+        { role: "user", content: "fala transcrita" },
+      ]),
+      access_token: "token-xyz",
+      audioDurationMs: 1800,
+      sessionMeta: {
+        distinctId: "distinct-voz",
+        origem: "app-mobile",
+        sessaoId: "sessao-voz",
+      },
+    },
+    file: {
+      buffer: Buffer.from("abcdef"),
+    },
+  } as any;
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(trackCalls.length, 1);
+
+  const event = trackCalls[0];
+  assert.equal(event.origem, "voz");
+  assert.equal(event.tipo, "continuacao");
+  assert.equal(event.tamanhoBytes, 6);
+  assert.equal(event.duracaoMs, 1800);
+  assert.equal(event.tamanhoCaracteres, "fala transcrita".length);
+  assert.equal(event.userId, "user-voz");
+  assert.equal(event.distinctId, "distinct-voz");
+  assert.equal(event.sessaoId, "sessao-voz");
+  assert.equal(event.origemSessao, "app-mobile");
+  assert.ok(typeof event.timestamp === "string");
+  assert.ok(!Number.isNaN(Date.parse(event.timestamp)));
+});


### PR DESCRIPTION
## Summary
- add a trackMensagemRecebida helper in the Mixpanel analytics module so incoming messages log origin, size/duration, and timestamps
- trigger the new event from the text and voice ask routes with conversation context metadata and voice-specific measurements
- cover the new tracking behaviour with route-level tests that stub dependencies and assert the analytics payload

## Testing
- node --loader ts-node/esm --test server/tests/**/*.test.ts tests/*.test.ts *(fails: repository tests require a custom loader setup for TypeScript modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dc12c2e9b083259cdd63344d3732a5