### PR TITLE
Handle async bloco generation in fast replies

### DIFF
--- a/server/analytics/events/mixpanelEvents.ts
+++ b/server/analytics/events/mixpanelEvents.ts
@@ -50,14 +50,23 @@ export const trackMensagemEnviada = ({
   tempoRespostaMs,
   tokensUsados,
   modelo,
+  blocoStatus,
 }: TrackParams<{
   tempoRespostaMs?: number;
   tokensUsados?: number;
   modelo?: string;
+  blocoStatus: "pending" | "ready" | "missing" | "skipped";
 }>) => {
   mixpanel.track(
     'Mensagem enviada',
-    withDistinctId({ distinctId, userId, tempoRespostaMs, tokensUsados, modelo })
+    withDistinctId({
+      distinctId,
+      userId,
+      tempoRespostaMs,
+      tokensUsados,
+      modelo,
+      blocoStatus,
+    })
   );
 };
 
@@ -218,7 +227,7 @@ export const trackBlocoTecnico = ({
   intensidade,
   erro,
 }: TrackParams<{
-  status: 'success' | 'failure' | 'timeout';
+  status: 'success' | 'failure' | 'timeout' | 'pending';
   mode: 'fast' | 'full';
   skipBloco: boolean;
   duracaoMs?: number;


### PR DESCRIPTION
## Summary
- avoid awaiting bloco generation in fast mode and reuse background persistence to store the final analysis
- add Mixpanel telemetry for pending bloco status and ensure required fields are populated
- update response finalizer tests to tolerate missing fast-mode metadata and cover async processing

## Testing
- node --test --require ts-node/register server/tests/conversation/responseFinalizer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc2a33f49c8325af69dd675e4d7ec3