### PR TITLE
Refactor prompt context base caching to inject current message on demand

### DIFF
--- a/server/controllers/promptController.ts
+++ b/server/controllers/promptController.ts
@@ -27,9 +27,8 @@ export async function montarContextoEco(input: any): Promise<string> {
     skipSaudacao: !!input?.skipSaudacao,
   };
 
-  // O builder atual retorna string diretamente.
-  const prompt = await ContextBuilder.build(safe);
-  return prompt;
+  const contexto = await ContextBuilder.build(safe);
+  return contexto.montarMensagemAtual(safe.texto);
 }
 
 /**
@@ -38,8 +37,8 @@ export async function montarContextoEco(input: any): Promise<string> {
  */
 export const getPromptEcoPreview = async (_req: Request, res: Response) => {
   try {
-    const prompt = await ContextBuilder.build({ texto: "" });
-    res.json({ prompt });
+    const contexto = await ContextBuilder.build({ texto: "" });
+    res.json({ prompt: contexto.montarMensagemAtual("") });
   } catch (err: any) {
     console.warn("❌ Erro ao montar o prompt:", err);
     res.status(500).json({ error: "Erro ao montar o prompt" });

--- a/server/routes/openrouterRoutes.ts
+++ b/server/routes/openrouterRoutes.ts
@@ -135,7 +135,8 @@ router.post("/ask-eco", async (req: Request, res: Response) => {
       forcarMetodoViva: req.body?.forcarMetodoViva ?? false,
       aberturaHibrida: req.body?.aberturaHibrida ?? null,
     };
-    const prompt = await ContextBuilder.build(buildIn);
+    const contexto = await ContextBuilder.build(buildIn);
+    const prompt = contexto.montarMensagemAtual(ultimaMsg);
 
     if (isDebug()) {
       log.debug("[ask-eco] Contexto montado", {

--- a/server/services/conversation/contextCache.ts
+++ b/server/services/conversation/contextCache.ts
@@ -71,16 +71,17 @@ export class ContextCache {
       intensidade
     )}:ms${msCount}:v${vivaFlag}:d${derivadosFlag}:a${aberturaFlag}:h${heuristicasFlag}:e${embeddingFlag}`;
 
-    const cached = this.deps.cache.get(cacheKey);
-    if (cached && msCount === 0) {
+    const cachedBase = this.deps.cache.get(cacheKey);
+    if (cachedBase && msCount === 0) {
       if (this.deps.debug()) {
         this.deps.logger.debug("[Orchestrator] contexto via cache", { cacheKey });
       }
-      return cached;
+      return this.deps.builder.montarMensagemAtual(cachedBase, entrada);
     }
 
     const t0 = Date.now();
     const contexto = await this.deps.builder.build(params as any);
+    const prompt = contexto.montarMensagemAtual(entrada);
     if (this.deps.debug()) {
       this.deps.logger.debug("[Orchestrator] contexto construído", {
         ms: Date.now() - t0,
@@ -88,10 +89,10 @@ export class ContextCache {
     }
 
     if (nivel <= 2 && msCount === 0) {
-      this.deps.cache.set(cacheKey, contexto);
+      this.deps.cache.set(cacheKey, contexto.base);
     }
 
-    return contexto;
+    return prompt;
   }
 }
 

--- a/server/services/promptContext/index.ts
+++ b/server/services/promptContext/index.ts
@@ -24,7 +24,9 @@ export async function buildContextWithMeta(input: any): Promise<{ prompt: string
     });
   }
 
-  const prompt = await ContextBuilder.build(input);
+  const contexto = await ContextBuilder.build(input);
+  const textoAtual = typeof input?.texto === "string" ? input.texto : "";
+  const prompt = contexto.montarMensagemAtual(textoAtual);
 
   if (isDebug()) {
     log.debug("[montarContextoEco] concluído", {

--- a/server/services/promptContext/promptComposer.ts
+++ b/server/services/promptContext/promptComposer.ts
@@ -9,7 +9,11 @@ export type PromptComposerInput = {
   texto: string;
 };
 
-export function composePrompt({
+export type PromptComposerBaseInput = Omit<PromptComposerInput, "texto">;
+
+export const CURRENT_MESSAGE_PLACEHOLDER = "__ECO_MENSAGEM_ATUAL__";
+
+export function composePromptBase({
   nivel,
   memCount,
   forcarMetodoViva,
@@ -17,8 +21,7 @@ export function composePrompt({
   stitched,
   memRecallBlock = "",
   instructionText,
-  texto,
-}: PromptComposerInput): string {
+}: PromptComposerBaseInput): string {
   const header = [
     `Nível de abertura: ${nivel}`,
     memCount > 0 ? `Memórias (internas): ${memCount} itens` : `Memórias: none`,
@@ -39,9 +42,18 @@ export function composePrompt({
     "",
     instructionText,
     "",
-    `Mensagem atual: ${texto}`,
+    `Mensagem atual: ${CURRENT_MESSAGE_PLACEHOLDER}`,
   ]
     .filter(Boolean)
     .join("\n")
     .trim();
+}
+
+export function applyCurrentMessage(base: string, texto: string): string {
+  return base.replace(CURRENT_MESSAGE_PLACEHOLDER, texto);
+}
+
+export function composePrompt(input: PromptComposerInput): string {
+  const base = composePromptBase(input);
+  return applyCurrentMessage(base, input.texto);
 }

--- a/server/tests/promptContext/ContextBuilder.test.ts
+++ b/server/tests/promptContext/ContextBuilder.test.ts
@@ -23,7 +23,8 @@ const params = {
 };
 
 test("ContextBuilder inclui lembrete com o nome do usuário", async () => {
-  const prompt = await montarContextoEco(params);
+  const resultado = await montarContextoEco(params);
+  const prompt = resultado.montarMensagemAtual(params.texto);
   assert.match(
     prompt,
     /Usuário se chama Maria; use o nome apenas quando fizer sentido\./


### PR DESCRIPTION
## Summary
- extract the static prompt base in the composer and expose a helper to inject the current message text
- update ContextBuilder to return { base, montarMensagemAtual } and adjust callers plus the context cache to store only the base string
- extend cache tests to assert the latest texto is always applied even when reusing cached prompts

## Testing
- npx ts-node --esm tests/contextCache.test.ts *(fails: module resolution for conversation/contextCache)*
- npx ts-node --esm server/tests/promptContext/ContextBuilder.test.ts *(fails: ESM loader configuration)*
- npx tsc --noEmit -p server/tsconfig.json *(fails: missing ambient types for external packages)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d6438648325b866f528b91c2bbe