### PR TITLE
feat: stream ask-eco responses over SSE

### DIFF
--- a/server/core/ClaudeAdapter.ts
+++ b/server/core/ClaudeAdapter.ts
@@ -1,5 +1,7 @@
 // core/ClaudeAdapter.ts
 
+import { Readable } from "node:stream";
+
 import { httpAgent, httpsAgent } from "../adapters/OpenRouterAdapter";
 
 type Msg = { role: "system" | "user" | "assistant"; content: string };
@@ -8,7 +10,11 @@ type Msg = { role: "system" | "user" | "assistant"; content: string };
 type ORole = "system" | "user" | "assistant";
 interface ORMessage { role: ORole; content?: string }
 interface ORChoice { index?: number; message?: ORMessage; finish_reason?: string }
-interface ORUsage { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number }
+export interface ORUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
 interface ORError { message?: string; type?: string }
 interface ORChatCompletion {
   id?: string;
@@ -17,6 +23,31 @@ interface ORChatCompletion {
   usage?: ORUsage;
   error?: ORError;
   [k: string]: unknown;
+}
+
+interface ORDeltaChoice {
+  index?: number;
+  delta?: { content?: string; role?: ORole; stop_reason?: string; finish_reason?: string };
+  finish_reason?: string | null;
+}
+
+interface ORStreamChunk {
+  id?: string;
+  model?: string;
+  choices?: ORDeltaChoice[];
+  usage?: ORUsage;
+  error?: ORError;
+  [k: string]: unknown;
+}
+
+export type ClaudeStreamControlEvent =
+  | { type: "reconnect"; attempt: number; raw?: unknown }
+  | { type: "done"; finishReason?: string | null; usage?: ORUsage; model?: string | null };
+
+export interface ClaudeStreamCallbacks {
+  onChunk?: (chunk: { content: string; raw: ORStreamChunk }) => void | Promise<void>;
+  onControl?: (event: ClaudeStreamControlEvent) => void | Promise<void>;
+  onError?: (error: Error) => void | Promise<void>;
 }
 
 const DEFAULT_TIMEOUT_MS = 12_000;
@@ -132,5 +163,214 @@ export async function claudeChatCompletion({
       : `Claude ${model} falhou, tentando fallback ${fallbackModel}`;
     console.warn(`${label} ${message}`, err);
     return await call(fallbackModel!);
+  }
+}
+
+export async function streamClaudeChatCompletion(
+  {
+    messages,
+    model = process.env.ECO_CLAUDE_MODEL || "anthropic/claude-sonnet-4",
+    temperature = 0.5,
+    maxTokens = 700,
+  }: {
+    messages: Msg[];
+    model?: string;
+    temperature?: number;
+    maxTokens?: number;
+  },
+  callbacks: ClaudeStreamCallbacks
+): Promise<void> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENROUTER_API_KEY ausente no ambiente.");
+  }
+
+  const system = messages.find((m) => m.role === "system")?.content ?? "";
+  const turns: ORMessage[] = messages
+    .filter((m) => m.role !== "system")
+    .map((m) => ({ role: m.role, content: m.content }));
+
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    "HTTP-Referer": process.env.PUBLIC_APP_URL || "http://localhost:5173",
+    "X-Title": "Eco App - ClaudeAdapter",
+  };
+
+  const payload = {
+    model,
+    temperature,
+    max_tokens: maxTokens,
+    stream: true,
+    messages: [
+      ...(system ? [{ role: "system", content: system } as ORMessage] : []),
+      ...turns,
+    ],
+  };
+
+  const resp = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    agent: (parsedURL: URL) => (parsedURL.protocol === "http:" ? httpAgent : httpsAgent),
+  } as any);
+
+  if (!resp.ok) {
+    throw new Error(`OpenRouter error: ${resp.status} ${resp.statusText}`);
+  }
+
+  const body = resp.body as ReadableStream<Uint8Array> | null;
+  if (!body) {
+    throw new Error("OpenRouter streaming response sem corpo.");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let reconnectAttempt = 0;
+  let doneEmitted = false;
+  let latestUsage: ORUsage | undefined;
+  let latestModel: string | null | undefined;
+  let latestFinish: string | null | undefined;
+
+  const handleEvent = async (rawEvent: string) => {
+    const trimmed = rawEvent.trim();
+    if (!trimmed) return;
+
+    const lines = trimmed.split(/\r?\n/);
+    let eventName = "message";
+    const dataLines: string[] = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      if (line.startsWith(":")) {
+        // LATENCY: ignora heartbeats imediatos sem gerar carga.
+        continue;
+      }
+      if (line.startsWith("event:")) {
+        eventName = line.slice(6).trim();
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).trim());
+      }
+    }
+
+    const dataPayload = dataLines.join("\n");
+    if (!dataPayload) return;
+
+    if (dataPayload === "[DONE]") {
+      doneEmitted = true;
+      await callbacks.onControl?.({
+        type: "done",
+        finishReason: latestFinish,
+        usage: latestUsage,
+        model: latestModel ?? model,
+      });
+      return;
+    }
+
+    let parsed: ORStreamChunk | null = null;
+    try {
+      parsed = JSON.parse(dataPayload) as ORStreamChunk;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      await callbacks.onError?.(err);
+      return;
+    }
+
+    if (parsed?.error?.message) {
+      const err = new Error(parsed.error.message);
+      await callbacks.onError?.(err);
+      return;
+    }
+
+    if (eventName && eventName.toLowerCase().includes("reconnect")) {
+      reconnectAttempt += 1;
+      await callbacks.onControl?.({ type: "reconnect", attempt: reconnectAttempt, raw: parsed });
+      return;
+    }
+
+    if ((parsed as any)?.type === "heartbeat") {
+      // LATENCY: heartbeat recebido — apenas mantém a conexão viva.
+      return;
+    }
+
+    const choice = parsed?.choices?.[0];
+    const deltaText = choice?.delta?.content ?? "";
+    const finishReason =
+      choice?.finish_reason ?? choice?.delta?.finish_reason ?? choice?.delta?.stop_reason ?? null;
+
+    if (parsed?.usage) {
+      latestUsage = parsed.usage;
+    }
+    if (parsed?.model) {
+      latestModel = parsed.model;
+    }
+    if (finishReason) {
+      latestFinish = finishReason;
+    }
+
+    if (deltaText) {
+      // LATENCY: entrega incremental do token renderizável.
+      await callbacks.onChunk?.({ content: deltaText, raw: parsed });
+    }
+  };
+
+  const flushBuffer = async (force = false) => {
+    let separatorIndex = buffer.indexOf("\n\n");
+    while (separatorIndex >= 0) {
+      const rawEvent = buffer.slice(0, separatorIndex);
+      buffer = buffer.slice(separatorIndex + 2);
+      await handleEvent(rawEvent);
+      separatorIndex = buffer.indexOf("\n\n");
+    }
+
+    if (force && buffer.trim()) {
+      await handleEvent(buffer);
+      buffer = "";
+    }
+  };
+
+  const reader = (body as any).getReader?.() as ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+  try {
+    if (reader) {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) {
+          // LATENCY: decodifica chunk SSE imediatamente.
+          buffer += decoder.decode(value, { stream: true });
+          await flushBuffer();
+        }
+      }
+    } else {
+      const nodeStream =
+        typeof Readable.fromWeb === "function"
+          ? Readable.fromWeb(body as any)
+          : Readable.from(body as any);
+      for await (const chunk of nodeStream) {
+        if (!chunk) continue;
+        // LATENCY: decodifica chunk SSE imediatamente (fallback Node stream).
+        buffer += decoder.decode(chunk as Buffer, { stream: true });
+        await flushBuffer();
+      }
+    }
+
+    buffer += decoder.decode(new Uint8Array(), { stream: false });
+    await flushBuffer(true);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    await callbacks.onError?.(err);
+    throw err;
+  }
+
+  if (!doneEmitted) {
+    await callbacks.onControl?.({
+      type: "done",
+      finishReason: latestFinish,
+      usage: latestUsage,
+      model: latestModel ?? model,
+    });
   }
 }

--- a/web/src/api/chatStreamClient.ts
+++ b/web/src/api/chatStreamClient.ts
@@ -1,0 +1,56 @@
+import { startEcoStream, type EcoClientEvent, type EcoStreamHandle } from "./ecoStream";
+
+export interface StreamCallbacks {
+  onText?: (text: string) => void;
+  onEvent?: (event: EcoClientEvent) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface StreamConversationParams {
+  payload: unknown;
+  token: string;
+  signal?: AbortSignal;
+  endpoint?: string;
+  callbacks: StreamCallbacks;
+}
+
+export interface ConversationStream {
+  close: () => void;
+  finished: Promise<void>;
+}
+
+export function streamConversation({
+  payload,
+  token,
+  signal,
+  endpoint,
+  callbacks,
+}: StreamConversationParams): ConversationStream {
+  let aggregated = "";
+
+  const handle: EcoStreamHandle = startEcoStream({
+    body: payload,
+    token,
+    signal,
+    endpoint,
+    onEvent: (event) => {
+      callbacks.onEvent?.(event);
+
+      if (event.type === "chunk") {
+        aggregated += event.delta;
+        // LATENCY: repassa o texto parcial para atualizar o UI em tempo real.
+        callbacks.onText?.(aggregated);
+      }
+
+      if (event.type === "done" && callbacks.onText) {
+        callbacks.onText(aggregated);
+      }
+    },
+    onError: callbacks.onError,
+  });
+
+  return {
+    close: () => handle.close(),
+    finished: handle.finished,
+  };
+}

--- a/web/src/api/ecoStream.ts
+++ b/web/src/api/ecoStream.ts
@@ -1,0 +1,130 @@
+import { decodeSseChunk } from "../utils/decodeSse";
+
+export type EcoClientEvent =
+  | { type: "prompt_ready" }
+  | { type: "first_token" }
+  | { type: "chunk"; delta: string; index: number }
+  | { type: "reconnect"; attempt?: number }
+  | { type: "done"; meta?: Record<string, unknown> }
+  | { type: "error"; message: string };
+
+export interface StartEcoStreamParams {
+  body: unknown;
+  token: string;
+  onEvent: (event: EcoClientEvent) => void;
+  onError?: (error: Error) => void;
+  signal?: AbortSignal;
+  endpoint?: string;
+}
+
+export interface EcoStreamHandle {
+  close: () => void;
+  finished: Promise<void>;
+}
+
+export function startEcoStream({
+  body,
+  token,
+  onEvent,
+  onError,
+  signal,
+  endpoint = "/ask-eco",
+}: StartEcoStreamParams): EcoStreamHandle {
+  const controller = new AbortController();
+
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+    } else {
+      signal.addEventListener(
+        "abort",
+        () => {
+          controller.abort(signal.reason);
+        },
+        { once: true }
+      );
+    }
+  }
+
+  const finished = (async () => {
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const error = new Error(`Eco stream HTTP ${response.status}`);
+        onError?.(error);
+        throw error;
+      }
+
+      const stream = response.body;
+      if (!stream) {
+        const error = new Error("Fluxo SSE indisponível na resposta");
+        onError?.(error);
+        throw error;
+      }
+
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        // LATENCY: decodifica chunk do fetch imediatamente para minimizar atraso visual.
+        buffer += decoder.decode(value, { stream: true });
+
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary >= 0) {
+          const rawPacket = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          const decoded = decodeSseChunk(rawPacket);
+
+          for (const entry of decoded) {
+            if (!entry.data) continue;
+            try {
+              const payload = JSON.parse(entry.data) as EcoClientEvent;
+              // LATENCY: entrega cada token/control para renderização imediata.
+              onEvent(payload);
+            } catch (parseErr) {
+              console.warn("[startEcoStream] Falha ao decodificar SSE:", parseErr);
+            }
+          }
+
+          boundary = buffer.indexOf("\n\n");
+        }
+      }
+
+      if (buffer.trim()) {
+        const tail = decodeSseChunk(buffer);
+        for (const entry of tail) {
+          if (!entry.data) continue;
+          try {
+            const payload = JSON.parse(entry.data) as EcoClientEvent;
+            onEvent(payload);
+          } catch (parseErr) {
+            console.warn("[startEcoStream] Falha ao decodificar resto do SSE:", parseErr);
+          }
+        }
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      const err = error instanceof Error ? error : new Error(String(error));
+      onError?.(err);
+      throw err;
+    }
+  })();
+
+  return {
+    close: () => controller.abort(),
+    finished,
+  };
+}

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./ecoStream";
+export * from "./chatStreamClient";

--- a/web/src/utils/decodeSse.ts
+++ b/web/src/utils/decodeSse.ts
@@ -1,0 +1,38 @@
+export interface DecodedSseChunk {
+  event?: string;
+  data?: string;
+}
+
+export function decodeSseChunk(raw: string): DecodedSseChunk[] {
+  const events: DecodedSseChunk[] = [];
+  const segments = raw.split(/\n\n/);
+
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+
+    const lines = trimmed.split(/\r?\n/);
+    let eventName: string | undefined;
+    const dataLines: string[] = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      if (line.startsWith(":")) {
+        // LATENCY: ignora heartbeats mantendo o buffer enxuto.
+        continue;
+      }
+      if (line.startsWith("event:")) {
+        eventName = line.slice(6).trim();
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).trim());
+      }
+    }
+
+    if (dataLines.length === 0) continue;
+    events.push({ event: eventName, data: dataLines.join("\n") });
+  }
+
+  return events;
+}


### PR DESCRIPTION
## Summary
- convert /ask-eco into a server-sent events endpoint that streams control and chunk messages while deferring post-processing
- add a Claude streaming adapter and update the conversation orchestrator to propagate incremental tokens with latency hints
- publish web helpers for decoding SSE payloads and consuming the ask-eco stream incrementally

## Testing
- npm --prefix server run build *(fails: missing ambient types for existing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dd320c2bc483259903481132b15544