### PR TITLE
Add latency instrumentation for streaming responses

### DIFF
--- a/web/src/api/chatStreamClient.ts
+++ b/web/src/api/chatStreamClient.ts
@@ -1,9 +1,34 @@
-import { startEcoStream, type EcoClientEvent, type EcoStreamHandle } from "./ecoStream";
+import {
+  startEcoStream,
+  type EcoClientEvent,
+  type EcoStreamHandle,
+  type EcoLatencyEvent,
+  type EcoLatencyTimings,
+  type EcoLatencyStage,
+} from "./ecoStream";
+
+export interface StreamAnalyticsDurations {
+  promptReadyMs?: number;
+  ttfbMs?: number;
+  ttlcMs?: number;
+  abortMs?: number;
+}
+
+export interface StreamAnalyticsPayload {
+  reason: "completed" | "aborted" | "error";
+  startedAt: number;
+  finishedAt: number;
+  durations: StreamAnalyticsDurations;
+  latencies: Partial<Record<EcoLatencyStage, EcoLatencyEvent>>;
+  timings?: EcoLatencyTimings;
+}
 
 export interface StreamCallbacks {
   onText?: (text: string) => void;
   onEvent?: (event: EcoClientEvent) => void;
   onError?: (error: Error) => void;
+  onLatency?: (latency: EcoLatencyEvent) => void;
+  onAnalytics?: (payload: StreamAnalyticsPayload) => void;
 }
 
 export interface StreamConversationParams {
@@ -27,6 +52,60 @@ export function streamConversation({
   callbacks,
 }: StreamConversationParams): ConversationStream {
   let aggregated = "";
+  const startedAt = Date.now();
+  const latencies: Partial<Record<EcoLatencyStage, EcoLatencyEvent>> = {};
+  let analyticsSent = false;
+
+  const emitAnalytics = (
+    reason: "completed" | "aborted" | "error",
+    options: { finishedAt?: number; event?: EcoLatencyEvent } = {}
+  ) => {
+    if (analyticsSent) return;
+    analyticsSent = true;
+    const finishedAt = options.finishedAt ?? Date.now();
+    const durations: StreamAnalyticsDurations = {
+      promptReadyMs: latencies.prompt_ready?.sinceStartMs,
+      ttfbMs: latencies.ttfb?.sinceStartMs,
+      ttlcMs: reason === "completed" ? latencies.ttlc?.sinceStartMs : undefined,
+      abortMs: reason === "aborted" ? finishedAt - startedAt : undefined,
+    };
+    const timings =
+      latencies.ttlc?.timings ??
+      latencies.prompt_ready?.timings ??
+      latencies.ttfb?.timings ??
+      options.event?.timings;
+
+    callbacks.onAnalytics?.({
+      reason,
+      startedAt,
+      finishedAt,
+      durations,
+      latencies: { ...latencies },
+      timings,
+    });
+  };
+
+  const registerLatency = (entry: EcoLatencyEvent) => {
+    latencies[entry.stage] = entry;
+    callbacks.onLatency?.(entry);
+    if (entry.stage === "ttlc") {
+      emitAnalytics("completed", { finishedAt: Date.now(), event: entry });
+    }
+  };
+
+  const markAbort = () => {
+    if (analyticsSent) return;
+    const at = Date.now();
+    const abortEvent: EcoLatencyEvent = {
+      type: "latency",
+      stage: "abort",
+      at,
+      sinceStartMs: at - startedAt,
+    };
+    latencies.abort = abortEvent;
+    callbacks.onLatency?.(abortEvent);
+    emitAnalytics("aborted", { finishedAt: at });
+  };
 
   const handle: EcoStreamHandle = startEcoStream({
     body: payload,
@@ -34,6 +113,9 @@ export function streamConversation({
     signal,
     endpoint,
     onEvent: (event) => {
+      if (event.type === "latency") {
+        registerLatency(event);
+      }
       callbacks.onEvent?.(event);
 
       if (event.type === "chunk") {
@@ -46,11 +128,25 @@ export function streamConversation({
         callbacks.onText(aggregated);
       }
     },
-    onError: callbacks.onError,
+    onError: (error) => {
+      emitAnalytics("error", { finishedAt: Date.now() });
+      callbacks.onError?.(error);
+    },
   });
 
+  if (signal) {
+    if (signal.aborted) {
+      markAbort();
+    } else {
+      signal.addEventListener("abort", markAbort, { once: true });
+    }
+  }
+
   return {
-    close: () => handle.close(),
+    close: () => {
+      markAbort();
+      handle.close();
+    },
     finished: handle.finished,
   };
 }

--- a/web/src/api/ecoStream.ts
+++ b/web/src/api/ecoStream.ts
@@ -1,12 +1,30 @@
 import { decodeSseChunk } from "../utils/decodeSse";
 
+export type EcoLatencyStage = "prompt_ready" | "ttfb" | "ttlc" | "abort";
+
+export interface EcoLatencyTimings {
+  contextBuildStart?: number;
+  contextBuildEnd?: number;
+  llmStart?: number;
+  llmEnd?: number;
+}
+
+export interface EcoLatencyEvent {
+  type: "latency";
+  stage: EcoLatencyStage;
+  at: number;
+  sinceStartMs: number;
+  timings?: EcoLatencyTimings;
+}
+
 export type EcoClientEvent =
-  | { type: "prompt_ready" }
+  | { type: "prompt_ready"; at?: number; sinceStartMs?: number; timings?: EcoLatencyTimings }
   | { type: "first_token" }
   | { type: "chunk"; delta: string; index: number }
   | { type: "reconnect"; attempt?: number }
-  | { type: "done"; meta?: Record<string, unknown> }
-  | { type: "error"; message: string };
+  | { type: "done"; meta?: Record<string, unknown>; at?: number; sinceStartMs?: number; timings?: EcoLatencyTimings }
+  | { type: "error"; message: string }
+  | EcoLatencyEvent;
 
 export interface StartEcoStreamParams {
   body: unknown;


### PR DESCRIPTION
## Summary
- capture latency milestones in the orchestrator and surface them through control events
- propagate server-side timestamps through /ask-eco SSE responses and log prompt/TTFB/TTLC markers
- extend the web SSE client to store latency data, fire analytics callbacks, and register abort deltas

## Testing
- npx tsc --noEmit *(prints TypeScript CLI help because the repo has no tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3645fbbc83258ef391d6ef1c1b3e