### PR TITLE
Limit RAG fan-out and tighten memory formatting

### DIFF
--- a/server/routes/openrouterRoutes.ts
+++ b/server/routes/openrouterRoutes.ts
@@ -167,7 +167,7 @@ router.post("/ask-eco", async (req: Request, res: Response) => {
       memsSimilares = await buscarMemoriasSemelhantes(usuario_id, {
         userEmbedding: queryEmbedding,
         texto: queryEmbedding ? undefined : ultimaMsg,
-        k: 5,
+        k: 4, // LATENCY: top_k
         threshold,
       });
       log.info(

--- a/server/services/conversation/parallelFetch.ts
+++ b/server/services/conversation/parallelFetch.ts
@@ -56,7 +56,7 @@ export class ParallelFetchService {
         .getHeuristicas({
           usuarioId: userId ?? null,
           userEmbedding,
-          matchCount: 5,
+          matchCount: 4, // LATENCY: top_k
         })
         .catch(() => []);
 

--- a/server/services/heuristicaService.ts
+++ b/server/services/heuristicaService.ts
@@ -20,7 +20,7 @@ export type BuscarHeuristicasInput = {
   usuarioId?: string | null;
   userEmbedding?: number[];   // se vier, não recalcula
   threshold?: number;         // default 0.80
-  matchCount?: number;        // default 5
+  matchCount?: number;        // default 4
   hydrate?: boolean;          // default true
 };
 
@@ -70,14 +70,14 @@ export async function buscarHeuristicasSemelhantes(
   input: string | BuscarHeuristicasInput,
   usuarioIdArg?: string | null,
   thresholdArg = 0.8,
-  matchCountArg = 5
+  matchCountArg = 4
 ): Promise<Heuristica[]> {
   // normalização de parâmetros
   let texto = "";
   let userEmbedding: number[] | undefined;
   let usuarioId: string | null = null;
   let threshold = clamp01(Number(thresholdArg) || 0.8);
-  let matchCount = Math.max(1, Number(matchCountArg) || 5);
+  let matchCount = Math.max(1, Number(matchCountArg) || 4);
   let hydrate = true;
 
   if (typeof input === "string") {
@@ -101,6 +101,8 @@ export async function buscarHeuristicasSemelhantes(
     tag: "🔍 heuristica",
   });
   if (!queryEmbedding) return [];
+
+  matchCount = Math.min(Math.max(1, matchCount), 4); // LATENCY: top_k
 
   return _buscarHeuristicasCore({
     queryEmbedding,
@@ -126,7 +128,7 @@ export async function buscarHeuristicaPorSimilaridade(
     queryEmbedding,
     usuarioId: usuarioId ?? null,
     threshold: clamp01(threshold),
-    matchCount: Math.max(1, matchCount),
+    matchCount: Math.min(Math.max(1, matchCount), 4), // LATENCY: top_k
     hydrate: false, // hidrataremos só arquivo para log
   });
 

--- a/server/services/promptContext/memoryRecall.ts
+++ b/server/services/promptContext/memoryRecall.ts
@@ -1,4 +1,44 @@
 import type { SimilarMemoryList } from "./contextTypes";
+import { countTokens } from "../../utils/text";
+
+const TOKEN_LIMIT = 350;
+
+function normalizeAndLimit(text: string): string {
+  const normalized = (text || "").replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+
+  if (countTokens(normalized) <= TOKEN_LIMIT) {
+    return normalized;
+  }
+
+  // LATENCY: truncar excerto para caber no orçamento de tokens por memória.
+  let low = 0;
+  let high = normalized.length;
+  let best = "";
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = normalized.slice(0, mid).trim();
+    if (!candidate) {
+      high = mid - 1;
+      continue;
+    }
+
+    if (countTokens(candidate) <= TOKEN_LIMIT) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  let finalText = best || normalized.slice(0, Math.max(1, high)).trim();
+  while (finalText.length > 1 && countTokens(`${finalText}…`) > TOKEN_LIMIT) {
+    finalText = finalText.slice(0, -1).trim();
+  }
+
+  return `${finalText}…`;
+}
 
 export function formatMemRecall(mems: SimilarMemoryList): string {
   if (!mems || !mems.length) return "";
@@ -10,7 +50,7 @@ export function formatMemRecall(mems: SimilarMemoryList): string {
     memory?.conteudo ||
     "";
 
-  const linhas = mems.slice(0, 3).map((memory) => {
+  const linhas = mems.slice(0, 4).map((memory) => {
     const sim =
       typeof memory?.similarity === "number"
         ? memory.similarity
@@ -19,13 +59,17 @@ export function formatMemRecall(mems: SimilarMemoryList): string {
         : undefined;
 
     const pct = typeof sim === "number" ? ` ~${Math.round(sim * 100)}%` : "";
-    const linha = String(pickText(memory)).replace(/\s+/g, " ").slice(0, 220);
-    return `- ${linha}${linha.length >= 220 ? "…" : ""}${pct}`;
+    const value = normalizeAndLimit(String(pickText(memory)));
+    return value ? `- ${value}${pct}` : "";
   });
 
-  return [
+  const blocos = linhas.filter(Boolean);
+  if (!blocos.length) return "";
+
+  const header = [
     "CONTINUIDADE — SINAIS DO HISTÓRICO (use com leveza, sem afirmar que “lembra”):",
-    ...linhas,
     "Se (e somente se) fizer sentido, pode contextualizar com: “uma coisa que você compartilhou foi…”.",
   ].join("\n");
+
+  return [header, ...blocos].join("\n---\n");
 }

--- a/server/tests/conversation/parallelFetch.test.ts
+++ b/server/tests/conversation/parallelFetch.test.ts
@@ -92,7 +92,7 @@ test("encaminha embedding para heurísticas e memórias quando disponível", asy
   assert.deepStrictEqual(calls.getHeuristicas[0], {
     usuarioId: "user-123",
     userEmbedding: fakeEmbedding,
-    matchCount: 5,
+    matchCount: 4,
   });
   assert.deepStrictEqual(calls.getMemorias[0], ["user-123", {
     texto: "quero entender meus padrões",


### PR DESCRIPTION
## Summary
- cap memory lookups at four items, annotate the latency-sensitive limit, and align the router calls with the new ceiling
- enforce the same top_k budget for heuristic retrieval, including the parallel fetch flow and accompanying tests
- normalize and token-trim recalled memory snippets before joining them with separators to keep context payloads bounded

## Testing
- node --test --require ts-node/register server/tests/conversation/parallelFetch.test.ts
- node --test --require ts-node/register server/tests/services/buscarHeuristicasSemelhantes.test.ts
- node --test --require ts-node/register server/tests/services/buscarMemoriasSemelhantes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd39e178248325a7aa314cc0e187af