### PR TITLE
Warm openrouter embeddings before orchestrator run

### DIFF
--- a/server/tests/routes/mensagemRecebidaAnalytics.test.ts
+++ b/server/tests/routes/mensagemRecebidaAnalytics.test.ts
@@ -95,6 +95,9 @@ test("/ask-eco delega prompt ao orquestrador e propaga eventos de prompt_ready",
         },
       },
     },
+    "../adapters/EmbeddingAdapter": {
+      getEmbeddingCached: async () => [],
+    },
     "../services/ConversationOrchestrator": {
       getEcoResponse: async (params: any) => {
         orchestratorCalls.push(params);

--- a/tests/openrouterRoutesCache.test.ts
+++ b/tests/openrouterRoutesCache.test.ts
@@ -36,6 +36,9 @@ const originalLoad = (Module as any)._load;
   if (request === "dotenv") {
     return { config: () => ({}) };
   }
+  if (request === "../adapters/EmbeddingAdapter") {
+    return { getEmbeddingCached: async () => [] };
+  }
   return originalLoad.call(this, request, parent, isMain);
 };
 


### PR DESCRIPTION
## Summary
- warm the /ask-eco route by calling the cached embedding adapter before delegating to the orchestrator
- adjust the route-focused tests to stub the new embedding adapter entry point

## Testing
- npx ts-node tests/openrouterRoutesCache.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2a49ab1448325807a4c51d7d6ac56