### PR TITLE
Adjust RPC result naming in memorias controller

### DIFF
--- a/server/controllers/memoriasController.ts
+++ b/server/controllers/memoriasController.ts
@@ -30,7 +30,7 @@ export async function registrarMemoriaHandler(req: Request, res: Response) {
     // pegue o token do header Authorization, se seu helper exigir
     const supabaseClient = supabaseWithBearer(token);
 
-    const { data, error } = await supabaseClient.rpc("registrar_memoria", {
+    const { data: rpcData, error } = await supabaseClient.rpc("registrar_memoria", {
       p_usuario: usuarioId,
       p_texto: texto ?? "",
       p_intensidade: intensidade,
@@ -42,7 +42,7 @@ export async function registrarMemoriaHandler(req: Request, res: Response) {
 
     if (error) return res.status(400).json({ error: error.message });
 
-    const row = Array.isArray(data) ? data[0] : data;
+    const row = Array.isArray(rpcData) ? rpcData[0] : rpcData;
     if (!row) return res.status(500).json({ error: "RPC não retornou dados" });
 
     return res.json({


### PR DESCRIPTION
## Summary
- rename the RPC call result destructuring to use a distinct `rpcData` alias
- update the row extraction logic to reference `rpcData`

## Testing
- npm run build *(fails: Missing script "build")*


------
https://chatgpt.com/codex/tasks/task_e_68e2ba5427248325a4350ac4c8d3d191