### PR TITLE
Require userId for eco orchestrator parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "tsc --noEmit -p tsconfig.json"
+  },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/node": "^24.5.2",

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -23,7 +23,7 @@ export type ProactivePayload = {
 
 export type GetEcoParams = {
   messages: ChatMessage[];
-  userId?: string;
+  userId: string;
   userName?: string;
   accessToken: string;
   mems?: any[];

--- a/tests/relatorioEmocionalRoutes.test.ts
+++ b/tests/relatorioEmocionalRoutes.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import type { Request } from "express";
 import {
   DEFAULT_RELATORIO_VIEW,
   extractDistinctId,
   extractRelatorioView,
 } from "../server/routes/relatorioEmocionalView";
+
+type RelatorioRequest = Parameters<typeof extractRelatorioView>[0];
 
 type TestCase = { name: string; run: () => Promise<void> | void };
 
@@ -14,12 +15,12 @@ function test(name: string, run: () => Promise<void> | void) {
   tests.push({ name, run });
 }
 
-function makeRequest(overrides: Partial<Request>): Request {
+function makeRequest(overrides: Partial<RelatorioRequest>): RelatorioRequest {
   return {
     query: {},
     headers: {},
     ...overrides,
-  } as Request;
+  } as RelatorioRequest;
 }
 
 test("defaults to mapa when no view provided", () => {


### PR DESCRIPTION
## Summary
- make the Conversation Orchestrator `GetEcoParams` type require a userId
- update the relatorio view tests to derive their request type from the orchestrator helper
- add a build script that runs `tsc --noEmit` so type-checking can be executed via npm run build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2be46e64083259ba0903d9708e02a