### PR TITLE
docs: outline refactor plan for conversation orchestrator

### DIFF
--- a/docs/conversation-orchestrator-refactor.md
+++ b/docs/conversation-orchestrator-refactor.md
@@ -1,69 +1,36 @@
-# ConversationOrchestrator refactor proposal
+# Conversation Orchestrator Refactor Notes
 
-## Pain points observed
+## Current Responsibilities
+- Builds final stream payload metadata (`buildFinalizedStreamText`, `buildStreamingMetaPayload`).
+- Handles micro responses and greeting pipeline fallbacks.
+- Coordinates routing, context loading, prompt building, and LLM execution (fast vs full modes).
+- Manages streaming control flow, chunk emission, bloco pipeline, and memory persistence.
+- Performs non-streaming fallback handling.
 
-- `ConversationOrchestrator.ts` currently mixes imports from adapters, caching, heuristics, prompt construction, analytics and delivery inside a single function, which makes the file sprawl to ~650 lines and multiple responsibilities. 【F:server/services/ConversationOrchestrator.ts†L1-L657】
-- The `getEcoResponse` flow alone contains routing, greeting handling, asynchronous fetches, prompt building, LLM invocation, response shaping, side-effects (memory persistence, analytics) and fallback logic in-line. 【F:server/services/ConversationOrchestrator.ts†L278-L654】
-- Helper utilities such as `operacoesParalelas`, `fastLaneLLM`, and `montarContextoOtimizado` are embedded in the same module even though they could be reused/tested independently. 【F:server/services/ConversationOrchestrator.ts†L92-L266】
+## Suggested Module Decomposition
+1. **Response Post-Processing Module**
+   - Move `buildFinalizedStreamText` and `buildStreamingMetaPayload` into a dedicated helper focused on response transformation and metadata extraction.
+   - Extract `salvarMemoriaViaRPC` into a `MemoryPersistenceService` that can be reused by streaming and non-streaming flows.
+2. **Entry Routing Pipeline**
+   - Encapsulate the micro-response and greeting handling into a `PreLLMDecision` module returning either a prepared response or instructions to continue with the main pipeline.
+3. **Context Preparation Service**
+   - Create a module responsible for `loadConversationContext` invocation and `defaultContextCache.build` call, returning the computed system prompt and context artifacts.
+4. **LLM Execution Orchestrators**
+   - Split the streaming and non-streaming execution paths into separate orchestrators that accept injected dependencies (LLM client, response finalizer, event emitter) and return standardized results.
+5. **Orchestrator Facade**
+   - Keep `getEcoResponse` as a thin facade that wires the modules together, handles dependency injection, and chooses the path based on routing decisions.
 
-## Suggested modular split
+## Testing Strategy
+- **Unit Tests**
+  - Validate metadata builders with focused tests for edge cases.
+  - Mock Supabase client to assert that `MemoryPersistenceService` calls RPCs conditionally and handles errors.
+  - Ensure routing module behavior using stubbed inputs to cover micro, greeting, fast, and full paths.
+  - For context preparation, mock dependencies to verify prompt construction decisions.
+- **Integration Tests**
+  - Exercise streaming orchestrator with fake LLM stream to assert event emission ordering and bloco pipeline interactions.
+  - Test non-streaming flow to ensure finalization and memory persistence interactions.
 
-1. **Entry-point orchestrator**
-   - Keep a lean `getEcoResponse` that orchestrates high-level steps by composing collaborators.
-   - Extract external dependencies behind interfaces (e.g. `ClaudeClient`, `SupabaseClient`, `ContextBuilderService`) that can be injected.
-
-2. **Greeting and micro-response pipeline**
-   - Move greeting detection (`respostaSaudacaoAutomatica`, `GreetGuard`, redundant greeting stripping) into `services/conversation/greeting.ts` to encapsulate the conditions and allow unit tests for first-response handling. 【F:server/services/ConversationOrchestrator.ts†L308-L353】【F:server/services/ConversationOrchestrator.ts†L424-L437】
-
-3. **Routing & heuristics module**
-   - Create a `ConversationRouter` responsible for `isLowComplexity`, `heuristicaPreViva`, and deciding between fast-lane and full flow. This router can expose `route(messages, flags): "fast" | "full"` and be unit-tested with crafted message fixtures. 【F:server/services/ConversationOrchestrator.ts†L77-L217】【F:server/services/ConversationOrchestrator.ts†L358-L440】
-
-4. **Parallel fetch service**
-   - Extract `operacoesParalelas` and `withTimeoutOrNull` into `services/conversation/parallelFetch.ts` so the orchestrator merely invokes `await parallelFetch.run(params)`. Provide dependency injection for embedding lookup, heuristics service, and memory search to make mocks trivial. 【F:server/services/ConversationOrchestrator.ts†L92-L155】【F:server/services/ConversationOrchestrator.ts†L444-L517】
-
-5. **Context assembly module**
-   - Wrap `montarContextoOtimizado` logic in a `ContextCache` class that receives `PROMPT_CACHE` and `ContextBuilder`. This class could also compute the cache key and log timings, keeping orchestration logic focused on control flow. 【F:server/services/ConversationOrchestrator.ts†L158-L197】
-
-6. **Response formatting & persistence**
-   - Consolidate the repeated block that cleans/strips greetings, enriches with bloco técnico, triggers async persistence, and tracks analytics into a `ResponseFinalizer`. It can expose `finalize({ rawResponse, bloco, metadata })` and be reused by both fast and full routes. 【F:server/services/ConversationOrchestrator.ts†L262-L438】【F:server/services/ConversationOrchestrator.ts†L563-L654】
-
-7. **Configuration & feature flags**
-   - Group the various env-driven constants (`ECO_*`) into a config module so tests can override them via dependency injection instead of process-level state.
-
-## Testing strategy
-
-- **Pure helpers**: add Jest unit tests for `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, and `heuristicaPreViva` with edge-case fixtures to lock behavior before refactoring. 【F:server/services/ConversationOrchestrator.ts†L53-L217】
-- **Router tests**: once routing logic is extracted, cover scenarios for fast-lane vs full, greeting suppression, and forced overrides using synthetic message arrays.
-- **Parallel fetch service**: inject fakes for embedding, heuristics, memories, and verify timeouts/fallbacks without hitting Supabase.
-- **Context cache**: test cache hit/miss behavior by stubbing `ContextBuilder.build` and asserting caching rules when `memoriasSemelhantes` exist.
-- **LLM clients**: wrap `claudeChatCompletion` behind an interface so tests can supply deterministic responses and exercise formatting/fallback paths for both fast and full pipelines.
-- **Integration slice tests**: create high-level tests that feed prepared messages into the orchestrator with stubbed dependencies to ensure analytics/memory side-effects are invoked (or skipped) as expected.
-
-## Isolation techniques
-
-- Introduce a `ConversationDependencies` object that is passed into the orchestrator, bundling external services. This makes it easy to stub them in tests.
-- Encapsulate background async fire-and-forget tasks (memory saving, analytics) inside a `PostProcessor` abstraction; in tests, expose hooks to await completion.
-- Normalize data structures into typed value objects (e.g. `ConversationContext`, `UserSignals`) to avoid loose `any` usage and simplify validation.
-- Consider moving feature toggles (e.g. greeting enablement) into a dedicated `FeatureFlags` service that can be toggled per test without mutating `process.env` globally.
-
-Implementing these steps incrementally—starting with extracting pure helpers and response finalization—will reduce the risk of regressions while making the codebase more testable and maintainable.
-
-## Suggested implementation roadmap
-
-| Iteration | Focus area | Deliverables | Notes |
-|-----------|------------|--------------|-------|
-| 1 | Extract pure utilities | Move `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, `heuristicaPreViva` into dedicated modules with unit tests. 【F:server/services/ConversationOrchestrator.ts†L53-L217】 | Enables snapshotting current behavior before heavier refactors. |
-| 2 | Response finalizer | Implement `ResponseFinalizer` abstraction and update orchestrator to consume it. 【F:server/services/ConversationOrchestrator.ts†L262-L654】 | Centralizes cleanup, analytics hooks, and persistence triggers. |
-| 3 | Greeting pipeline | Introduce `greeting.ts` service and route first-message logic through it. 【F:server/services/ConversationOrchestrator.ts†L308-L437】 | Unlocks independent testing of salutation handling. |
-| 4 | Router module | Create `ConversationRouter` with fast/full decision logic and accompanying tests. 【F:server/services/ConversationOrchestrator.ts†L77-L440】 | Keeps complexity heuristics separated from orchestration. |
-| 5 | Parallel fetch service | Extract `operacoesParalelas` into `parallelFetch.ts` and wire via dependency injection. 【F:server/services/ConversationOrchestrator.ts†L92-L517】 | Simplifies async control flow and facilitates timeout simulations. |
-| 6 | Context cache service | Replace inline cache usage with `ContextCache` class and add coverage. 【F:server/services/ConversationOrchestrator.ts†L158-L197】 | Encapsulates cache key construction and logging. |
-| 7 | Dependency bundle & feature flags | Introduce `ConversationDependencies` and `FeatureFlags` modules. | Finalize seam creation for future changes and environment-specific toggles. |
-
-## Tracking refactor progress
-
-- Create a short-lived branch per iteration to keep pull requests reviewable.
-- For each extracted module, publish a README or JSDoc comment describing its contract and collaborators.
-- Maintain a checklist in the main refactor ticket mirroring the roadmap table above; mark tasks complete as modules migrate.
-- After iterations 3 and 4, run an integration smoke test (staging conversation) to ensure routing/greeting behavior remains intact.
-- Schedule a pairing or review session after iteration 5 to validate that parallel fetch error handling still meets product requirements.
+## Isolation Techniques
+- Introduce dependency injection for external services (Supabase, LLM clients, response finalizer) to allow mocking.
+- Use interfaces for event emitters and bloco handlers to decouple from concrete implementations.
+- Provide factory functions to build orchestrators with default dependencies for production, but allow overrides during tests.


### PR DESCRIPTION
## Summary
- document the current responsibilities handled by `ConversationOrchestrator`
- outline recommended module boundaries for splitting orchestration duties
- propose testing and isolation techniques to support the refactor

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e30f70db888325ab1793b8e5c33e53