### PR TITLE
refactor conversation orchestrator into modular services

### DIFF
--- a/docs/conversation-orchestrator-refactor.md
+++ b/docs/conversation-orchestrator-refactor.md
@@ -1,69 +1,36 @@
-# ConversationOrchestrator refactor proposal
+# Conversation Orchestrator Refactor Notes
 
-## Pain points observed
+## Current Responsibilities
+- Builds final stream payload metadata (`buildFinalizedStreamText`, `buildStreamingMetaPayload`).
+- Handles micro responses and greeting pipeline fallbacks.
+- Coordinates routing, context loading, prompt building, and LLM execution (fast vs full modes).
+- Manages streaming control flow, chunk emission, bloco pipeline, and memory persistence.
+- Performs non-streaming fallback handling.
 
-- `ConversationOrchestrator.ts` currently mixes imports from adapters, caching, heuristics, prompt construction, analytics and delivery inside a single function, which makes the file sprawl to ~650 lines and multiple responsibilities. 【F:server/services/ConversationOrchestrator.ts†L1-L657】
-- The `getEcoResponse` flow alone contains routing, greeting handling, asynchronous fetches, prompt building, LLM invocation, response shaping, side-effects (memory persistence, analytics) and fallback logic in-line. 【F:server/services/ConversationOrchestrator.ts†L278-L654】
-- Helper utilities such as `operacoesParalelas`, `fastLaneLLM`, and `montarContextoOtimizado` are embedded in the same module even though they could be reused/tested independently. 【F:server/services/ConversationOrchestrator.ts†L92-L266】
+## Suggested Module Decomposition
+1. **Response Post-Processing Module**
+   - Move `buildFinalizedStreamText` and `buildStreamingMetaPayload` into a dedicated helper focused on response transformation and metadata extraction.
+   - Extract `salvarMemoriaViaRPC` into a `MemoryPersistenceService` that can be reused by streaming and non-streaming flows.
+2. **Entry Routing Pipeline**
+   - Encapsulate the micro-response and greeting handling into a `PreLLMDecision` module returning either a prepared response or instructions to continue with the main pipeline.
+3. **Context Preparation Service**
+   - Create a module responsible for `loadConversationContext` invocation and `defaultContextCache.build` call, returning the computed system prompt and context artifacts.
+4. **LLM Execution Orchestrators**
+   - Split the streaming and non-streaming execution paths into separate orchestrators that accept injected dependencies (LLM client, response finalizer, event emitter) and return standardized results.
+5. **Orchestrator Facade**
+   - Keep `getEcoResponse` as a thin facade that wires the modules together, handles dependency injection, and chooses the path based on routing decisions.
 
-## Suggested modular split
+## Testing Strategy
+- **Unit Tests**
+  - Validate metadata builders with focused tests for edge cases.
+  - Mock Supabase client to assert that `MemoryPersistenceService` calls RPCs conditionally and handles errors.
+  - Ensure routing module behavior using stubbed inputs to cover micro, greeting, fast, and full paths.
+  - For context preparation, mock dependencies to verify prompt construction decisions.
+- **Integration Tests**
+  - Exercise streaming orchestrator with fake LLM stream to assert event emission ordering and bloco pipeline interactions.
+  - Test non-streaming flow to ensure finalization and memory persistence interactions.
 
-1. **Entry-point orchestrator**
-   - Keep a lean `getEcoResponse` that orchestrates high-level steps by composing collaborators.
-   - Extract external dependencies behind interfaces (e.g. `ClaudeClient`, `SupabaseClient`, `ContextBuilderService`) that can be injected.
-
-2. **Greeting and micro-response pipeline**
-   - Move greeting detection (`respostaSaudacaoAutomatica`, `GreetGuard`, redundant greeting stripping) into `services/conversation/greeting.ts` to encapsulate the conditions and allow unit tests for first-response handling. 【F:server/services/ConversationOrchestrator.ts†L308-L353】【F:server/services/ConversationOrchestrator.ts†L424-L437】
-
-3. **Routing & heuristics module**
-   - Create a `ConversationRouter` responsible for `isLowComplexity`, `heuristicaPreViva`, and deciding between fast-lane and full flow. This router can expose `route(messages, flags): "fast" | "full"` and be unit-tested with crafted message fixtures. 【F:server/services/ConversationOrchestrator.ts†L77-L217】【F:server/services/ConversationOrchestrator.ts†L358-L440】
-
-4. **Parallel fetch service**
-   - Extract `operacoesParalelas` and `withTimeoutOrNull` into `services/conversation/parallelFetch.ts` so the orchestrator merely invokes `await parallelFetch.run(params)`. Provide dependency injection for embedding lookup, heuristics service, and memory search to make mocks trivial. 【F:server/services/ConversationOrchestrator.ts†L92-L155】【F:server/services/ConversationOrchestrator.ts†L444-L517】
-
-5. **Context assembly module**
-   - Wrap `montarContextoOtimizado` logic in a `ContextCache` class that receives `PROMPT_CACHE` and `ContextBuilder`. This class could also compute the cache key and log timings, keeping orchestration logic focused on control flow. 【F:server/services/ConversationOrchestrator.ts†L158-L197】
-
-6. **Response formatting & persistence**
-   - Consolidate the repeated block that cleans/strips greetings, enriches with bloco técnico, triggers async persistence, and tracks analytics into a `ResponseFinalizer`. It can expose `finalize({ rawResponse, bloco, metadata })` and be reused by both fast and full routes. 【F:server/services/ConversationOrchestrator.ts†L262-L438】【F:server/services/ConversationOrchestrator.ts†L563-L654】
-
-7. **Configuration & feature flags**
-   - Group the various env-driven constants (`ECO_*`) into a config module so tests can override them via dependency injection instead of process-level state.
-
-## Testing strategy
-
-- **Pure helpers**: add Jest unit tests for `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, and `heuristicaPreViva` with edge-case fixtures to lock behavior before refactoring. 【F:server/services/ConversationOrchestrator.ts†L53-L217】
-- **Router tests**: once routing logic is extracted, cover scenarios for fast-lane vs full, greeting suppression, and forced overrides using synthetic message arrays.
-- **Parallel fetch service**: inject fakes for embedding, heuristics, memories, and verify timeouts/fallbacks without hitting Supabase.
-- **Context cache**: test cache hit/miss behavior by stubbing `ContextBuilder.build` and asserting caching rules when `memoriasSemelhantes` exist.
-- **LLM clients**: wrap `claudeChatCompletion` behind an interface so tests can supply deterministic responses and exercise formatting/fallback paths for both fast and full pipelines.
-- **Integration slice tests**: create high-level tests that feed prepared messages into the orchestrator with stubbed dependencies to ensure analytics/memory side-effects are invoked (or skipped) as expected.
-
-## Isolation techniques
-
-- Introduce a `ConversationDependencies` object that is passed into the orchestrator, bundling external services. This makes it easy to stub them in tests.
-- Encapsulate background async fire-and-forget tasks (memory saving, analytics) inside a `PostProcessor` abstraction; in tests, expose hooks to await completion.
-- Normalize data structures into typed value objects (e.g. `ConversationContext`, `UserSignals`) to avoid loose `any` usage and simplify validation.
-- Consider moving feature toggles (e.g. greeting enablement) into a dedicated `FeatureFlags` service that can be toggled per test without mutating `process.env` globally.
-
-Implementing these steps incrementally—starting with extracting pure helpers and response finalization—will reduce the risk of regressions while making the codebase more testable and maintainable.
-
-## Suggested implementation roadmap
-
-| Iteration | Focus area | Deliverables | Notes |
-|-----------|------------|--------------|-------|
-| 1 | Extract pure utilities | Move `stripIdentityCorrection`, `stripRedundantGreeting`, `isLowComplexity`, `heuristicaPreViva` into dedicated modules with unit tests. 【F:server/services/ConversationOrchestrator.ts†L53-L217】 | Enables snapshotting current behavior before heavier refactors. |
-| 2 | Response finalizer | Implement `ResponseFinalizer` abstraction and update orchestrator to consume it. 【F:server/services/ConversationOrchestrator.ts†L262-L654】 | Centralizes cleanup, analytics hooks, and persistence triggers. |
-| 3 | Greeting pipeline | Introduce `greeting.ts` service and route first-message logic through it. 【F:server/services/ConversationOrchestrator.ts†L308-L437】 | Unlocks independent testing of salutation handling. |
-| 4 | Router module | Create `ConversationRouter` with fast/full decision logic and accompanying tests. 【F:server/services/ConversationOrchestrator.ts†L77-L440】 | Keeps complexity heuristics separated from orchestration. |
-| 5 | Parallel fetch service | Extract `operacoesParalelas` into `parallelFetch.ts` and wire via dependency injection. 【F:server/services/ConversationOrchestrator.ts†L92-L517】 | Simplifies async control flow and facilitates timeout simulations. |
-| 6 | Context cache service | Replace inline cache usage with `ContextCache` class and add coverage. 【F:server/services/ConversationOrchestrator.ts†L158-L197】 | Encapsulates cache key construction and logging. |
-| 7 | Dependency bundle & feature flags | Introduce `ConversationDependencies` and `FeatureFlags` modules. | Finalize seam creation for future changes and environment-specific toggles. |
-
-## Tracking refactor progress
-
-- Create a short-lived branch per iteration to keep pull requests reviewable.
-- For each extracted module, publish a README or JSDoc comment describing its contract and collaborators.
-- Maintain a checklist in the main refactor ticket mirroring the roadmap table above; mark tasks complete as modules migrate.
-- After iterations 3 and 4, run an integration smoke test (staging conversation) to ensure routing/greeting behavior remains intact.
-- Schedule a pairing or review session after iteration 5 to validate that parallel fetch error handling still meets product requirements.
+## Isolation Techniques
+- Introduce dependency injection for external services (Supabase, LLM clients, response finalizer) to allow mocking.
+- Use interfaces for event emitters and bloco handlers to decouple from concrete implementations.
+- Provide factory functions to build orchestrators with default dependencies for production, but allow overrides during tests.

--- a/server/core/ClaudeAdapter.ts
+++ b/server/core/ClaudeAdapter.ts
@@ -4,7 +4,7 @@ import { Readable } from "node:stream";
 
 import { httpAgent, httpsAgent } from "../adapters/OpenRouterAdapter";
 
-type Msg = { role: "system" | "user" | "assistant"; content: string };
+export type Msg = { role: "system" | "user" | "assistant"; content: string };
 
 /** Tipos mínimos do retorno da OpenRouter (compatível com strict) */
 type ORole = "system" | "user" | "assistant";

--- a/server/routes/openrouterRoutes.ts
+++ b/server/routes/openrouterRoutes.ts
@@ -5,10 +5,10 @@ import { supabase } from "../lib/supabaseAdmin"; // ✅ usa a instância (não �
 
 import {
   getEcoResponse,
-  buildFinalizedStreamText,
   type EcoStreamHandler,
   type EcoLatencyMarks,
 } from "../services/ConversationOrchestrator";
+import { buildFinalizedStreamText } from "../services/conversation/responseMetadata";
 import type { GetEcoResult } from "../utils";
 import { extractSessionMeta } from "./sessionMeta";
 import { trackEcoCache, trackMensagemRecebida } from "../analytics/events/mixpanelEvents";

--- a/server/services/ConversationOrchestrator.ts
+++ b/server/services/ConversationOrchestrator.ts
@@ -1,4 +1,3 @@
-// server/services/ConversationOrchestrator.ts
 import {
   ensureEnvs,
   now,
@@ -9,216 +8,35 @@ import {
 } from "../utils";
 import { supabaseWithBearer } from "../adapters/SupabaseAdapter";
 import { microReflexoLocal } from "../core/ResponseGenerator";
-import {
-  claudeChatCompletion,
-  streamClaudeChatCompletion,
-  type ClaudeStreamControlEvent,
-  type ORUsage,
-} from "../core/ClaudeAdapter";
-import { log, isDebug } from "../services/promptContext/logger";
+import { claudeChatCompletion } from "../core/ClaudeAdapter";
+import { log, isDebug } from "./promptContext/logger";
 
 import { defaultGreetingPipeline } from "./conversation/greeting";
 import { defaultConversationRouter } from "./conversation/router";
-import { loadConversationContext } from "./conversation/derivadosLoader";
-import { defaultContextCache } from "./conversation/contextCache";
-import {
-  defaultResponseFinalizer,
-  type NormalizedEcoResponse,
-  type PrecomputedFinalizeArtifacts,
-} from "./conversation/responseFinalizer";
-import { firstName } from "./conversation/helpers";
 import { runFastLaneLLM } from "./conversation/fastLane";
 import { buildFullPrompt } from "./conversation/promptPlan";
+import { defaultResponseFinalizer } from "./conversation/responseFinalizer";
+import { firstName } from "./conversation/helpers";
 
-export function buildFinalizedStreamText(result: GetEcoResult): string {
-  const intensidade = typeof result.intensidade === "number" ? result.intensidade : null;
-  const resumo = typeof result.resumo === "string" ? result.resumo : null;
-  const emocao = typeof result.emocao === "string" ? result.emocao : null;
-  const tags = Array.isArray(result.tags) ? result.tags : [];
-  const categoria = typeof result.categoria === "string" ? result.categoria : null;
-  const proactive = result.proactive ?? null;
+import { handlePreLLMShortcuts } from "./conversation/preLLMPipeline";
+import { prepareConversationContext } from "./conversation/contextPreparation";
+import { executeStreamingLLM } from "./conversation/streamingOrchestrator";
+import { executeFullLLM } from "./conversation/fullOrchestrator";
 
-  const payload: Record<string, unknown> = {
-    intensidade,
-    resumo,
-    emocao,
-    tags,
-    categoria,
-    proactive,
-  };
+import type {
+  EcoStreamHandler,
+  EcoStreamingResult,
+  EcoLatencyMarks,
+  EcoStreamEvent,
+} from "./conversation/types";
 
-  const hasMeta =
-    intensidade !== null ||
-    (typeof resumo === "string" && resumo.trim() !== "") ||
-    (typeof emocao === "string" && emocao.trim() !== "") ||
-    (Array.isArray(tags) && tags.length > 0) ||
-    (typeof categoria === "string" && categoria.trim() !== "") ||
-    proactive !== null;
+export { getEcoResponse as getEcoResponseOtimizado };
+export type { EcoStreamEvent, EcoStreamHandler, EcoStreamingResult, EcoLatencyMarks };
 
-  if (!hasMeta) {
-    return result.message ?? "";
-  }
-
-  return `${result.message ?? ""}\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
-}
-
-function buildStreamingMetaPayload(
-  bloco: any,
-  cleanedFallback: string
-): EcoStreamMetaPayload | null {
-  if (!bloco || typeof bloco !== "object") {
-    return null;
-  }
-
-  const intensidade =
-    typeof bloco.intensidade === "number" && Number.isFinite(bloco.intensidade)
-      ? bloco.intensidade
-      : null;
-  const resumo =
-    typeof bloco.analise_resumo === "string" ? bloco.analise_resumo.trim() : "";
-  const emocao =
-    typeof bloco.emocao_principal === "string" ? bloco.emocao_principal.trim() : "";
-  const categoria =
-    typeof bloco.categoria === "string" ? bloco.categoria.trim() : "";
-  const tags = Array.isArray(bloco.tags)
-    ? bloco.tags
-        .map((tag: any) => (typeof tag === "string" ? tag.trim() : ""))
-        .filter((tag: string) => tag.length > 0)
-    : [];
-
-  if (
-    intensidade === null ||
-    resumo.length === 0 ||
-    emocao.length === 0 ||
-    categoria.length === 0 ||
-    tags.length === 0
-  ) {
-    return null;
-  }
-
-  return {
-    intensidade,
-    resumo: resumo || cleanedFallback,
-    emocao,
-    categoria,
-    tags,
-  };
-}
-
-/* ---------------------------- Consts ---------------------------- */
-
-const BLOCO_DEADLINE_MS = Number(process.env.ECO_BLOCO_DEADLINE_MS ?? 5000);
-const BLOCO_PENDING_MS = Number(process.env.ECO_BLOCO_PENDING_MS ?? 1000);
-
-interface EcoStreamMetaPayload {
-  intensidade: number;
-  resumo: string;
-  emocao: string;
-  categoria: string;
-  tags: string[];
-}
-
-export interface EcoLatencyMarks {
-  contextBuildStart?: number;
-  contextBuildEnd?: number;
-  llmStart?: number;
-  llmEnd?: number;
-}
-
-export type EcoStreamEvent =
-  | {
-      type: "control";
-      name: "prompt_ready" | "first_token" | "reconnect";
-      attempt?: number;
-      timings?: EcoLatencyMarks;
-    }
-  | {
-      type: "control";
-      name: "done";
-      meta?: { finishReason?: string | null; usage?: ORUsage; modelo?: string | null; length?: number };
-      timings?: EcoLatencyMarks;
-    }
-  | {
-      type: "control";
-      name: "meta_pending";
-    }
-  | {
-      type: "control";
-      name: "meta";
-      meta: EcoStreamMetaPayload;
-    }
-  | {
-      // ✅ NOVO: evento emitido após persistir a memória via RPC
-      type: "control";
-      name: "memory_saved";
-      meta: {
-        memoriaId: string;
-        primeiraMemoriaSignificativa: boolean;
-        intensidade: number;
-      };
-    }
-  | { type: "chunk"; content: string; index: number }
-  | { type: "error"; error: Error };
-
-export interface EcoStreamHandler {
-  onEvent: (event: EcoStreamEvent) => void | Promise<void>;
-}
-
-export interface EcoStreamingResult {
-  raw: string;
-  modelo?: string | null;
-  usage?: ORUsage;
-  finalize: () => Promise<GetEcoResult>;
-  timings: EcoLatencyMarks;
-}
-
-/* ---------------------- RPC Memory Helper ---------------------- */
-/** Salva memória via RPC registrar_memoria (idempotente para milestone) e
- * retorna se é a primeira memória >=7 para o usuário (primeira = true). */
-async function salvarMemoriaViaRPC(opts: {
-  supabase: any;                    // Supabase client já autenticado com bearer do usuário
-  userId: string;
-  mensagemId?: string | null;
-  meta: EcoStreamMetaPayload;       // { intensidade, resumo, emocao, categoria, tags }
-  origem?: string;                  // "streaming_bloco" | "full_sync"
-}) {
-  const { supabase, userId, mensagemId, meta, origem = "streaming_bloco" } = opts;
-
-  if (meta.intensidade < 7) {
-    return { saved: false as const, primeira: false, memoriaId: null as string | null };
-  }
-
-  const { data, error } = await supabase.rpc("registrar_memoria", {
-    p_usuario: userId,
-    p_texto: meta.resumo ?? "",
-    p_intensidade: meta.intensidade,
-    p_tags: (meta.tags && meta.tags.length ? meta.tags : null),
-    p_dominio_vida: meta.categoria ?? null,
-    p_padrao_comportamental: null,
-    p_meta: {
-      origem,
-      mensagem_id: mensagemId ?? null,
-      emocao_principal: meta.emocao ?? null,
-    }
-  });
-
-  if (error) {
-    log.warn("[registrar_memoria RPC] erro ao salvar memoria", { message: error.message });
-    return { saved: false as const, primeira: false, memoriaId: null as string | null };
-  }
-
-  const row = Array.isArray(data) ? data[0] : data;
-  return {
-    saved: true as const,
-    primeira: !!row?.primeira,
-    memoriaId: row?.id ?? null
-  };
-}
-
-export function getEcoResponse(
+export async function getEcoResponse(
   params: GetEcoParams & { promptOverride?: string; metaFromBuilder?: any }
 ): Promise<GetEcoResult>;
-export function getEcoResponse(
+export async function getEcoResponse(
   params: GetEcoParams & {
     promptOverride?: string;
     metaFromBuilder?: any;
@@ -226,24 +44,22 @@ export function getEcoResponse(
   }
 ): Promise<EcoStreamingResult>;
 
-/* -------------------------- Orquestrador ------------------------ */
-
-export async function getEcoResponse(
-  {
-    messages,
-    userId,
-    userName,
-    accessToken,
-    mems = [],
-    forcarMetodoViva = false,
-    blocoTecnicoForcado = null,
-    clientHour,
-    promptOverride,
-    metaFromBuilder,
-    sessionMeta,
-    stream,
-  }: GetEcoParams & { promptOverride?: string; metaFromBuilder?: any; stream?: EcoStreamHandler }
-): Promise<GetEcoResult | EcoStreamingResult> {
+export async function getEcoResponse({
+  messages,
+  userId,
+  userName,
+  accessToken,
+  mems = [],
+  forcarMetodoViva = false,
+  blocoTecnicoForcado = null,
+  clientHour,
+  promptOverride,
+  metaFromBuilder,
+  sessionMeta,
+  stream,
+}: GetEcoParams & { promptOverride?: string; metaFromBuilder?: any; stream?: EcoStreamHandler }): Promise<
+  GetEcoResult | EcoStreamingResult
+> {
   ensureEnvs();
 
   if (!Array.isArray(messages) || messages.length === 0) {
@@ -257,110 +73,37 @@ export async function getEcoResponse(
 
   const streamHandler = stream ?? null;
   const timings: EcoLatencyMarks = {};
-  const emitStream = async (event: EcoStreamEvent) => {
-    if (!streamHandler) return;
-    await streamHandler.onEvent(event);
-  };
 
   const supabase = supabaseWithBearer(accessToken);
   const hasAssistantBeforeInThread = thread
     .slice(0, -1)
     .some((msg) => mapRoleForOpenAI(msg.role) === "assistant");
 
-  // Micro-resposta local
-  const micro = microReflexoLocal(ultimaMsg);
-  if (micro) {
-    const startedAt = now();
-    const finalized = await defaultResponseFinalizer.finalize({
-      raw: micro,
+  const preLLM = await handlePreLLMShortcuts(
+    {
+      thread,
       ultimaMsg,
-      userName,
-      hasAssistantBefore: hasAssistantBeforeInThread,
       userId,
+      userName,
       supabase,
+      hasAssistantBefore: hasAssistantBeforeInThread,
       lastMessageId: lastMessageId ?? undefined,
-      mode: "fast",
-      startedAt,
-      usageTokens: undefined,
-      modelo: "micro-reflexo",
       sessionMeta,
-      sessaoId: sessionMeta?.sessaoId ?? undefined,
-      origemSessao: sessionMeta?.origem ?? undefined,
-    });
-    const finalText = buildFinalizedStreamText(finalized);
-
-    if (streamHandler) {
-      await emitStream({ type: "control", name: "prompt_ready" });
-      await emitStream({ type: "control", name: "first_token" });
-      await emitStream({ type: "chunk", content: finalText, index: 0 });
-      await emitStream({
-        type: "control",
-        name: "done",
-        meta: { length: finalText.length, modelo: "micro-reflexo" },
-      });
-      const finalize = async () => finalized;
-      return {
-        raw: finalText,
-        modelo: "micro-reflexo",
-        usage: undefined,
-        finalize,
-        timings: {},
-      };
+      streamHandler,
+      clientHour,
+    },
+    {
+      microResponder: microReflexoLocal,
+      greetingPipeline: defaultGreetingPipeline,
+      responseFinalizer: defaultResponseFinalizer,
+      now,
     }
-    return finalized;
+  );
+
+  if (preLLM) {
+    return preLLM.result;
   }
 
-  // Pipeline de saudação
-  const greetingResult = defaultGreetingPipeline.handle({
-    messages: thread,
-    ultimaMsg,
-    userId,
-    userName,
-    clientHour,
-    greetingEnabled: process.env.ECO_GREETING_BACKEND_ENABLED !== "0",
-  });
-  if (greetingResult.handled && greetingResult.response) {
-    const startedAt = now();
-    const finalized = await defaultResponseFinalizer.finalize({
-      raw: greetingResult.response,
-      ultimaMsg,
-      userName,
-      hasAssistantBefore: hasAssistantBeforeInThread,
-      userId,
-      supabase,
-      lastMessageId: lastMessageId ?? undefined,
-      mode: "fast",
-      startedAt,
-      usageTokens: undefined,
-      modelo: "greeting",
-      sessionMeta,
-      sessaoId: sessionMeta?.sessaoId ?? undefined,
-      origemSessao: sessionMeta?.origem ?? undefined,
-    });
-    const finalText = buildFinalizedStreamText(finalized);
-
-    if (streamHandler) {
-      await emitStream({ type: "control", name: "prompt_ready" });
-      await emitStream({ type: "control", name: "first_token" });
-      await emitStream({ type: "chunk", content: finalText, index: 0 });
-      await emitStream({
-        type: "control",
-        name: "done",
-        meta: { length: finalText.length, modelo: "greeting" },
-      });
-      const finalize = async () => finalized;
-      return {
-        raw: finalText,
-        modelo: "greeting",
-        usage: undefined,
-        finalize,
-        timings: {},
-      };
-    }
-    return finalized;
-  }
-
-  // Roteamento
   const decision = defaultConversationRouter.decide({
     messages: thread,
     ultimaMsg,
@@ -379,12 +122,11 @@ export async function getEcoResponse(
     });
   }
 
-  // --------------------------- FAST MODE ---------------------------
   if (decision.mode === "fast" && !streamHandler) {
     const inicioFast = now();
     const fast = await runFastLaneLLM({
       messages: thread,
-      userName,
+      userName: userName ?? undefined,
       ultimaMsg,
       hasAssistantBefore: decision.hasAssistantBefore,
       userId,
@@ -402,47 +144,28 @@ export async function getEcoResponse(
     return fast.response;
   }
 
-  // --------------------------- FULL MODE ---------------------------
   timings.contextBuildStart = now();
   log.info("// LATENCY: context_build_start", { at: timings.contextBuildStart });
-  const {
-    heuristicas,
-    userEmbedding,
-    memsSemelhantes,
-    derivados,
-    aberturaHibrida,
-  } = await loadConversationContext(userId, ultimaMsg, supabase, {
+
+  const { systemPrompt } = await prepareConversationContext({
+    userId,
+    ultimaMsg,
+    supabase,
     promptOverride,
     metaFromBuilder,
+    mems,
+    userName,
+    forcarMetodoViva,
+    blocoTecnicoForcado,
+    decision,
     onDerivadosError: (error) => {
       if (isDebug()) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         log.debug("[Orchestrator] derivados fetch falhou", { message });
       }
     },
   });
 
-  // System prompt final (ou override)
-  const systemPrompt =
-    promptOverride ??
-    (await defaultContextCache.build({
-      userId,
-      userName,
-      perfil: null,
-      mems,
-      memoriasSemelhantes: memsSemelhantes,
-      forcarMetodoViva: decision.vivaAtivo,
-      blocoTecnicoForcado,
-      texto: ultimaMsg,
-      heuristicas,
-      userEmbedding,
-      skipSaudacao: true,
-      derivados,
-      aberturaHibrida,
-    }));
-
-  // Planejamento de prompt (seleção de estilo e orçamento)
   const { prompt, maxTokens } = buildFullPrompt({
     decision,
     ultimaMsg,
@@ -459,415 +182,37 @@ export async function getEcoResponse(
         : undefined,
   });
 
-  let inicioEco = now();
   const principalModel = process.env.ECO_CLAUDE_MODEL || "anthropic/claude-3-5-sonnet";
 
   if (streamHandler) {
-    const streamedChunks: string[] = [];
-    let chunkIndex = 0;
-    let firstTokenSent = false;
-    let usageFromStream: ORUsage | undefined;
-    let finishReason: string | null | undefined;
-    let modelFromStream: string | null | undefined;
-    let streamFailure: Error | null = null;
-
-    // DEFINITE ASSIGNMENT
-    let resolveRawForBloco!: (value: string) => void;
-    let rejectRawForBloco!: (reason?: unknown) => void;
-    const rawForBlocoPromise = new Promise<string>((resolve, reject) => {
-      resolveRawForBloco = resolve;
-      rejectRawForBloco = reject;
-    });
-
-    type StreamingBlocoArtifacts = {
-      normalized: NormalizedEcoResponse;
-      blocoPromise: Promise<any | null>;
-      blocoRacePromise: Promise<any | null>;
-    };
-
-    let blocoSetupPromise: Promise<StreamingBlocoArtifacts> | null = null;
-    let blocoPendingTimer: NodeJS.Timeout | null = null;
-    let blocoDeadlineTimer: NodeJS.Timeout | null = null;
-
-    const startBlocoPipeline = () => {
-      if (blocoSetupPromise) return;
-      blocoSetupPromise = (async () => {
-        try {
-          const rawForBloco = await rawForBlocoPromise;
-          const normalized = defaultResponseFinalizer.normalizeRawResponse({
-            raw: rawForBloco,
-            userName,
-            hasAssistantBefore: decision.hasAssistantBefore,
-            mode: "full",
-          });
-
-          const blocoTimeout = defaultResponseFinalizer.gerarBlocoComTimeout({
-            ultimaMsg,
-            blocoTarget: normalized.blocoTarget,
-            mode: "full",
-            skipBloco: false,
-            distinctId: sessionMeta?.distinctId ?? userId,
-            userId,
-          });
-
-          const blocoPromise = blocoTimeout.full;
-          const blocoRacePromise = blocoTimeout.race;
-
-          let settled = false;
-          let deadlineExceeded = false;
-          const blocoStartedAt = now();
-
-          const clearPending = () => {
-            if (blocoPendingTimer) {
-              clearTimeout(blocoPendingTimer);
-              blocoPendingTimer = null;
-            }
-          };
-
-          const clearDeadline = () => {
-            if (blocoDeadlineTimer) {
-              clearTimeout(blocoDeadlineTimer);
-              blocoDeadlineTimer = null;
-            }
-          };
-
-          blocoPromise
-            .catch(() => undefined)
-            .finally(() => {
-              settled = true;
-              clearPending();
-              clearDeadline();
-            });
-
-          blocoPendingTimer = setTimeout(() => {
-            if (settled || deadlineExceeded) return;
-            log.info("[StreamingBloco] state=pending", {
-              pendingMs: BLOCO_PENDING_MS,
-              deadlineMs: BLOCO_DEADLINE_MS,
-            });
-            void emitStream({ type: "control", name: "meta_pending" });
-            blocoPendingTimer = null;
-          }, BLOCO_PENDING_MS);
-
-          blocoDeadlineTimer = setTimeout(() => {
-            if (settled) return;
-            deadlineExceeded = true;
-            clearPending();
-            log.warn("[StreamingBloco] state=deadline_exceeded", {
-              deadlineMs: BLOCO_DEADLINE_MS,
-            });
-            blocoDeadlineTimer = null;
-          }, BLOCO_DEADLINE_MS);
-
-          blocoRacePromise
-            .then(async (payload) => {
-              if (deadlineExceeded) return;
-
-              const durationMs = now() - blocoStartedAt;
-              if (!payload) {
-                log.info("[StreamingBloco] state=success", { durationMs, emitted: false });
-                return;
-              }
-
-              const metaPayload = buildStreamingMetaPayload(payload, normalized.cleaned);
-              if (!metaPayload) {
-                log.warn("[StreamingBloco] bloco payload inválido; meta não emitido", { durationMs });
-                return;
-              }
-
-              log.info("[StreamingBloco] state=success", { durationMs, emitted: true });
-              // 1) Emite meta com os campos do bloco
-              await emitStream({ type: "control", name: "meta", meta: metaPayload });
-
-              // 2) Salva via RPC e emite memory_saved se aplicável
-              try {
-                const rpcRes = await salvarMemoriaViaRPC({
-                  supabase,
-                  userId,
-                  mensagemId: lastMessageId ?? null,
-                  meta: metaPayload,
-                  origem: "streaming_bloco",
-                });
-
-                if (rpcRes.saved && rpcRes.memoriaId) {
-                  await emitStream({
-                    type: "control",
-                    name: "memory_saved",
-                    meta: {
-                      memoriaId: rpcRes.memoriaId,
-                      primeiraMemoriaSignificativa: !!rpcRes.primeira,
-                      intensidade: metaPayload.intensidade,
-                    },
-                  });
-                }
-              } catch (e: any) {
-                log.warn("[StreamingBloco] salvarMemoriaViaRPC falhou (ignorado)", { message: e?.message });
-              }
-            })
-            .catch((error) => {
-              if (deadlineExceeded) return;
-              const message = error instanceof Error ? error.message : String(error);
-              log.warn("[StreamingBloco] bloco promise rejected", { message });
-            });
-
-          return { normalized, blocoPromise, blocoRacePromise };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          log.warn("[StreamingBloco] failed to start bloco", { message });
-          throw error;
-        }
-      })();
-    };
-
-    timings.llmStart = now();
-    inicioEco = timings.llmStart;
-    log.info("// LATENCY: llm_request_start", {
-      at: timings.llmStart,
-      sincePromptReadyMs:
-        timings.contextBuildEnd && timings.llmStart
-          ? timings.llmStart - timings.contextBuildEnd
-          : undefined,
-    });
-
-    const streamPromise = streamClaudeChatCompletion(
-      {
-        messages: prompt,
-        model: principalModel,
-        temperature: 0.6,
-        maxTokens,
-      },
-      {
-        async onChunk({ content }) {
-          if (!content) return;
-          streamedChunks.push(content);
-          if (!firstTokenSent) {
-            firstTokenSent = true;
-            await emitStream({ type: "control", name: "first_token" });
-          }
-          const currentIndex = chunkIndex;
-          chunkIndex += 1;
-          await emitStream({ type: "chunk", content, index: currentIndex });
-        },
-        async onControl(event: ClaudeStreamControlEvent) {
-          if (event.type === "reconnect") {
-            await emitStream({
-              type: "control",
-              name: "reconnect",
-              attempt: event.attempt,
-            });
-            return;
-          }
-          if (event.type === "done") {
-            usageFromStream = event.usage ?? usageFromStream;
-            finishReason = event.finishReason ?? finishReason;
-            modelFromStream = event.model ?? modelFromStream;
-          }
-        },
-        async onError(error: Error) {
-          streamFailure = error;
-          rejectRawForBloco(error);
-          await emitStream({ type: "error", error });
-        },
-      }
-    ).catch((error: any) => {
-      const err = error instanceof Error ? error : new Error(String(error));
-      streamFailure = err;
-      rejectRawForBloco(err);
-      throw err;
-    });
-
-    startBlocoPipeline();
-
-    const promptReadySnapshot = { ...timings };
-    await emitStream({ type: "control", name: "prompt_ready", timings: promptReadySnapshot });
-
-    try {
-      await streamPromise;
-    } finally {
-      timings.llmEnd = now();
-      log.info("// LATENCY: llm_request_end", {
-        at: timings.llmEnd,
-        durationMs:
-          timings.llmStart && timings.llmEnd
-            ? timings.llmEnd - timings.llmStart
-            : undefined,
-      });
-    }
-
-    if (streamFailure) {
-      throw streamFailure;
-    }
-
-    const raw = streamedChunks.join("");
-    resolveRawForBloco(raw);
-
-    let finalizePromise: Promise<GetEcoResult> | null = null;
-    const finalize = () => {
-      if (!finalizePromise) {
-        finalizePromise = (async () => {
-          let precomputed: PrecomputedFinalizeArtifacts | undefined;
-          if (blocoSetupPromise) {
-            try {
-              const artifacts = await blocoSetupPromise;
-              precomputed = {
-                normalized: artifacts.normalized,
-                blocoPromise: artifacts.blocoPromise,
-                blocoRacePromise: artifacts.blocoRacePromise,
-              };
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              log.warn("[StreamingBloco] finalize ignoring precomputed bloco", { message });
-            }
-          }
-
-          return defaultResponseFinalizer.finalize({
-            raw,
-            ultimaMsg,
-            userName,
-            hasAssistantBefore: decision.hasAssistantBefore,
-            userId,
-            supabase,
-            lastMessageId: lastMessageId ?? undefined,
-            mode: "full",
-            startedAt: inicioEco,
-            usageTokens: usageFromStream?.total_tokens ?? undefined,
-            modelo: modelFromStream ?? principalModel,
-            sessionMeta,
-            sessaoId: sessionMeta?.sessaoId ?? undefined,
-            origemSessao: sessionMeta?.origem ?? undefined,
-            precomputed,
-          });
-        })();
-      }
-      return finalizePromise;
-    };
-
-    const doneSnapshot = { ...timings };
-    await emitStream({
-      type: "control",
-      name: "done",
-      meta: {
-        finishReason,
-        usage: usageFromStream,
-        modelo: modelFromStream ?? principalModel,
-        length: raw.length,
-      },
-      timings: doneSnapshot,
-    });
-
-    return {
-      raw,
-      modelo: modelFromStream ?? principalModel,
-      usage: usageFromStream,
-      finalize,
-      timings: doneSnapshot,
-    };
-  }
-
-  // ---------------------- Caminho sem streaming ----------------------
-  let data: any;
-  timings.llmStart = now();
-  inicioEco = timings.llmStart;
-  log.info("// LATENCY: llm_request_start", {
-    at: timings.llmStart,
-    sincePromptReadyMs:
-      timings.contextBuildEnd && timings.llmStart
-        ? timings.llmStart - timings.contextBuildEnd
-        : undefined,
-  });
-  try {
-    data = await claudeChatCompletion({
-      messages: prompt,
-      model: principalModel,
-      temperature: 0.6,
+    return executeStreamingLLM({
+      prompt,
       maxTokens,
-    });
-  } catch (e: any) {
-    log.warn(`[getEcoResponse] LLM rota completa falhou: ${e?.message}`);
-    const msg = "Desculpa, tive um problema técnico agora. Topa tentar de novo?";
-    return defaultResponseFinalizer.finalize({
-      raw: msg,
+      principalModel,
+      decision,
       ultimaMsg,
       userName,
-      hasAssistantBefore: decision.hasAssistantBefore,
       userId,
       supabase,
       lastMessageId: lastMessageId ?? undefined,
-      mode: "full",
-      startedAt: inicioEco,
-      usageTokens: undefined,
-      modelo: "full-fallback",
-      skipBloco: true,
       sessionMeta,
-      sessaoId: sessionMeta?.sessaoId ?? undefined,
-      origemSessao: sessionMeta?.origem ?? undefined,
+      streamHandler,
+      timings,
     });
   }
 
-  timings.llmEnd = now();
-  log.info("// LATENCY: llm_request_end", {
-    at: timings.llmEnd,
-    durationMs:
-      timings.llmStart && timings.llmEnd ? timings.llmEnd - timings.llmStart : undefined,
-  });
-
-  if (isDebug()) {
-    log.debug("[Orchestrator] resposta pronta", {
-      duracaoEcoMs: now() - inicioEco,
-      lenMensagem: (data?.content || "").length,
-    });
-  }
-
-  const finalized = await defaultResponseFinalizer.finalize({
-    raw: data?.content ?? "",
+  return executeFullLLM({
+    prompt,
+    maxTokens,
+    principalModel,
     ultimaMsg,
     userName,
-    hasAssistantBefore: decision.hasAssistantBefore,
+    decision,
     userId,
     supabase,
     lastMessageId: lastMessageId ?? undefined,
-    mode: "full",
-    startedAt: inicioEco,
-    usageTokens: data?.usage?.total_tokens ?? undefined,
-    modelo: data?.model,
     sessionMeta,
-    sessaoId: sessionMeta?.sessaoId ?? undefined,
-    origemSessao: sessionMeta?.origem ?? undefined,
+    timings,
+    thread,
   });
-
-  // Persistência via RPC também no modo não-streaming
-  try {
-    const metaPayload = buildStreamingMetaPayload(
-      {
-        intensidade: finalized.intensidade,
-        analise_resumo: finalized.resumo,
-        emocao_principal: finalized.emocao,
-        categoria: finalized.categoria,
-        tags: finalized.tags,
-      } as any,
-      finalized.message ?? ""
-    );
-
-    if (metaPayload && metaPayload.intensidade >= 7) {
-      const rpcRes = await salvarMemoriaViaRPC({
-        supabase,
-        userId,
-        mensagemId: (thread.at(-1)?.id as string) ?? null,
-        meta: metaPayload,
-        origem: "full_sync",
-      });
-      if (rpcRes.saved) {
-        log.info("[FullSync] memoria salva via RPC", {
-          memoriaId: rpcRes.memoriaId,
-          primeira: rpcRes.primeira,
-        });
-      }
-    }
-  } catch (e: any) {
-    log.warn("[FullSync] salvarMemoriaViaRPC falhou (ignorado)", { message: e?.message });
-  }
-
-  return finalized;
 }
-
-export { getEcoResponse as getEcoResponseOtimizado };

--- a/server/services/conversation/contextPreparation.ts
+++ b/server/services/conversation/contextPreparation.ts
@@ -1,0 +1,61 @@
+import { loadConversationContext } from "./derivadosLoader";
+import { defaultContextCache } from "./contextCache";
+
+interface PrepareContextParams {
+  userId: string;
+  ultimaMsg: string;
+  supabase: any;
+  promptOverride?: string;
+  metaFromBuilder?: any;
+  mems: any[];
+  userName?: string | null;
+  forcarMetodoViva: boolean;
+  blocoTecnicoForcado: any;
+  decision: { vivaAtivo: boolean };
+  onDerivadosError?: (error: unknown) => void;
+}
+
+export interface PreparedContext {
+  systemPrompt: string;
+  context: Awaited<ReturnType<typeof loadConversationContext>>;
+}
+
+export async function prepareConversationContext({
+  userId,
+  ultimaMsg,
+  supabase,
+  promptOverride,
+  metaFromBuilder,
+  mems,
+  userName,
+  forcarMetodoViva,
+  blocoTecnicoForcado,
+  decision,
+  onDerivadosError,
+}: PrepareContextParams): Promise<PreparedContext> {
+  const context = await loadConversationContext(userId, ultimaMsg, supabase, {
+    promptOverride,
+    metaFromBuilder,
+    onDerivadosError,
+  });
+
+  const systemPrompt =
+    promptOverride ??
+    (await defaultContextCache.build({
+      userId,
+      userName: userName ?? undefined,
+      perfil: null,
+      mems,
+      memoriasSemelhantes: context.memsSemelhantes,
+      forcarMetodoViva: decision.vivaAtivo,
+      blocoTecnicoForcado,
+      texto: ultimaMsg,
+      heuristicas: context.heuristicas,
+      userEmbedding: context.userEmbedding,
+      skipSaudacao: true,
+      derivados: context.derivados,
+      aberturaHibrida: context.aberturaHibrida,
+    }));
+
+  return { systemPrompt, context };
+}

--- a/server/services/conversation/fullOrchestrator.ts
+++ b/server/services/conversation/fullOrchestrator.ts
@@ -1,0 +1,135 @@
+import { claudeChatCompletion, type Msg } from "../../core/ClaudeAdapter";
+import { log } from "../promptContext/logger";
+import { now } from "../../utils";
+
+import { buildStreamingMetaPayload } from "./responseMetadata";
+import { salvarMemoriaViaRPC } from "./memoryPersistence";
+import { defaultResponseFinalizer } from "./responseFinalizer";
+import type { ChatMessage, GetEcoResult } from "../../utils";
+import type { EcoLatencyMarks } from "./types";
+
+interface FullExecutionParams {
+  prompt: Msg[];
+  maxTokens: number;
+  principalModel: string;
+  ultimaMsg: string;
+  userName?: string | null;
+  decision: { hasAssistantBefore: boolean };
+  userId: string;
+  supabase: any;
+  lastMessageId?: string;
+  sessionMeta?: any;
+  timings: EcoLatencyMarks;
+  thread: ChatMessage[];
+}
+
+export async function executeFullLLM({
+  prompt,
+  maxTokens,
+  principalModel,
+  ultimaMsg,
+  userName,
+  decision,
+  userId,
+  supabase,
+  lastMessageId,
+  sessionMeta,
+  timings,
+  thread,
+}: FullExecutionParams): Promise<GetEcoResult> {
+  let data: any;
+  timings.llmStart = now();
+  log.info("// LATENCY: llm_request_start", {
+    at: timings.llmStart,
+    sincePromptReadyMs:
+      timings.contextBuildEnd && timings.llmStart
+        ? timings.llmStart - timings.contextBuildEnd
+        : undefined,
+  });
+
+  try {
+    data = await claudeChatCompletion({
+      messages: prompt,
+      model: principalModel,
+      temperature: 0.6,
+      maxTokens,
+    });
+  } catch (error: any) {
+    log.warn(`[getEcoResponse] LLM rota completa falhou: ${error?.message}`);
+    const msg = "Desculpa, tive um problema técnico agora. Topa tentar de novo?";
+    return defaultResponseFinalizer.finalize({
+      raw: msg,
+      ultimaMsg,
+      userName: userName ?? undefined,
+      hasAssistantBefore: decision.hasAssistantBefore,
+      userId,
+      supabase,
+      lastMessageId,
+      mode: "full",
+      startedAt: timings.llmStart,
+      usageTokens: undefined,
+      modelo: "full-fallback",
+      skipBloco: true,
+      sessionMeta,
+      sessaoId: sessionMeta?.sessaoId ?? undefined,
+      origemSessao: sessionMeta?.origem ?? undefined,
+    });
+  }
+
+  timings.llmEnd = now();
+  log.info("// LATENCY: llm_request_end", {
+    at: timings.llmEnd,
+    durationMs:
+      timings.llmStart && timings.llmEnd ? timings.llmEnd - timings.llmStart : undefined,
+  });
+
+  const finalized = await defaultResponseFinalizer.finalize({
+    raw: data?.content ?? "",
+    ultimaMsg,
+    userName: userName ?? undefined,
+    hasAssistantBefore: decision.hasAssistantBefore,
+    userId,
+    supabase,
+    lastMessageId,
+    mode: "full",
+    startedAt: timings.llmStart,
+    usageTokens: data?.usage?.total_tokens ?? undefined,
+    modelo: data?.model,
+    sessionMeta,
+    sessaoId: sessionMeta?.sessaoId ?? undefined,
+    origemSessao: sessionMeta?.origem ?? undefined,
+  });
+
+  try {
+    const metaPayload = buildStreamingMetaPayload(
+      {
+        intensidade: finalized.intensidade,
+        analise_resumo: finalized.resumo,
+        emocao_principal: finalized.emocao,
+        categoria: finalized.categoria,
+        tags: finalized.tags,
+      } as any,
+      finalized.message ?? ""
+    );
+
+    if (metaPayload && metaPayload.intensidade >= 7) {
+      const rpcRes = await salvarMemoriaViaRPC({
+        supabase,
+        userId,
+        mensagemId: (thread.at(-1)?.id as string) ?? null,
+        meta: metaPayload,
+        origem: "full_sync",
+      });
+      if (rpcRes.saved) {
+        log.info("[FullSync] memoria salva via RPC", {
+          memoriaId: rpcRes.memoriaId,
+          primeira: rpcRes.primeira,
+        });
+      }
+    }
+  } catch (error: any) {
+    log.warn("[FullSync] salvarMemoriaViaRPC falhou (ignorado)", { message: error?.message });
+  }
+
+  return finalized;
+}

--- a/server/services/conversation/memoryPersistence.ts
+++ b/server/services/conversation/memoryPersistence.ts
@@ -1,0 +1,45 @@
+import { log } from "../promptContext/logger";
+
+import type { EcoStreamMetaPayload } from "./types";
+
+/** Salva memória via RPC registrar_memoria (idempotente para milestone) e
+ * retorna se é a primeira memória >=7 para o usuário (primeira = true). */
+export async function salvarMemoriaViaRPC(opts: {
+  supabase: any;
+  userId: string;
+  mensagemId?: string | null;
+  meta: EcoStreamMetaPayload;
+  origem?: string;
+}) {
+  const { supabase, userId, mensagemId, meta, origem = "streaming_bloco" } = opts;
+
+  if (meta.intensidade < 7) {
+    return { saved: false as const, primeira: false, memoriaId: null as string | null };
+  }
+
+  const { data, error } = await supabase.rpc("registrar_memoria", {
+    p_usuario: userId,
+    p_texto: meta.resumo ?? "",
+    p_intensidade: meta.intensidade,
+    p_tags: meta.tags && meta.tags.length ? meta.tags : null,
+    p_dominio_vida: meta.categoria ?? null,
+    p_padrao_comportamental: null,
+    p_meta: {
+      origem,
+      mensagem_id: mensagemId ?? null,
+      emocao_principal: meta.emocao ?? null,
+    },
+  });
+
+  if (error) {
+    log.warn("[registrar_memoria RPC] erro ao salvar memoria", { message: error.message });
+    return { saved: false as const, primeira: false, memoriaId: null as string | null };
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  return {
+    saved: true as const,
+    primeira: !!row?.primeira,
+    memoriaId: row?.id ?? null,
+  };
+}

--- a/server/services/conversation/preLLMPipeline.ts
+++ b/server/services/conversation/preLLMPipeline.ts
@@ -1,0 +1,156 @@
+import type { GetEcoParams, GetEcoResult, ChatMessage } from "../../utils";
+
+import type {
+  EcoStreamHandler,
+  EcoStreamingResult,
+  EcoLatencyMarks,
+} from "./types";
+import { buildFinalizedStreamText } from "./responseMetadata";
+
+interface PreLLMShortcutsParams {
+  thread: ChatMessage[];
+  ultimaMsg: string;
+  userId: string;
+  userName?: string | null;
+  supabase: any;
+  hasAssistantBefore: boolean;
+  lastMessageId?: string;
+  sessionMeta?: GetEcoParams["sessionMeta"];
+  streamHandler?: EcoStreamHandler | null;
+  clientHour?: number;
+}
+
+interface PreLLMShortcutsDeps {
+  microResponder: typeof import("../../core/ResponseGenerator")["microReflexoLocal"];
+  greetingPipeline: typeof import("./greeting")["defaultGreetingPipeline"];
+  responseFinalizer: typeof import("./responseFinalizer")["defaultResponseFinalizer"];
+  now: typeof import("../../utils")["now"];
+}
+
+type PreLLMHandled =
+  | { kind: "final"; result: GetEcoResult }
+  | { kind: "stream"; result: EcoStreamingResult };
+
+export async function handlePreLLMShortcuts(
+  params: PreLLMShortcutsParams,
+  deps: PreLLMShortcutsDeps
+): Promise<PreLLMHandled | null> {
+  const {
+    thread,
+    ultimaMsg,
+    userId,
+    userName,
+    supabase,
+    hasAssistantBefore,
+    lastMessageId,
+    sessionMeta,
+    streamHandler,
+    clientHour,
+  } = params;
+  const { microResponder, greetingPipeline, responseFinalizer, now } = deps;
+
+  const startedAt = now();
+  const maybeMicro = microResponder(ultimaMsg);
+  if (maybeMicro) {
+    const finalized = await responseFinalizer.finalize({
+      raw: maybeMicro,
+      ultimaMsg,
+      userName: userName ?? undefined,
+      hasAssistantBefore,
+      userId,
+      supabase,
+      lastMessageId,
+      mode: "fast",
+      startedAt,
+      usageTokens: undefined,
+      modelo: "micro-reflexo",
+      sessionMeta,
+      sessaoId: sessionMeta?.sessaoId ?? undefined,
+      origemSessao: sessionMeta?.origem ?? undefined,
+    });
+
+    return streamHandler
+      ? {
+          kind: "stream",
+          result: await emitImmediateStream({
+            streamHandler,
+            finalized,
+            modelo: "micro-reflexo",
+          }),
+        }
+      : { kind: "final", result: finalized };
+  }
+
+  const greetingResult = greetingPipeline.handle({
+    messages: thread,
+    ultimaMsg,
+    userId,
+    userName: userName ?? undefined,
+    clientHour,
+    greetingEnabled: process.env.ECO_GREETING_BACKEND_ENABLED !== "0",
+  });
+
+  if (greetingResult.handled && greetingResult.response) {
+    const finalized = await responseFinalizer.finalize({
+      raw: greetingResult.response,
+      ultimaMsg,
+      userName: userName ?? undefined,
+      hasAssistantBefore,
+      userId,
+      supabase,
+      lastMessageId,
+      mode: "fast",
+      startedAt: now(),
+      usageTokens: undefined,
+      modelo: "greeting",
+      sessionMeta,
+      sessaoId: sessionMeta?.sessaoId ?? undefined,
+      origemSessao: sessionMeta?.origem ?? undefined,
+    });
+
+    return streamHandler
+      ? {
+          kind: "stream",
+          result: await emitImmediateStream({
+            streamHandler,
+            finalized,
+            modelo: "greeting",
+          }),
+        }
+      : { kind: "final", result: finalized };
+  }
+
+  return null;
+}
+
+async function emitImmediateStream({
+  streamHandler,
+  finalized,
+  modelo,
+}: {
+  streamHandler: EcoStreamHandler;
+  finalized: GetEcoResult;
+  modelo: string;
+}): Promise<EcoStreamingResult> {
+  const finalText = buildFinalizedStreamText(finalized);
+
+  const timings: EcoLatencyMarks = {};
+  await streamHandler.onEvent({ type: "control", name: "prompt_ready", timings });
+  await streamHandler.onEvent({ type: "control", name: "first_token", timings });
+  await streamHandler.onEvent({ type: "chunk", content: finalText, index: 0 });
+  await streamHandler.onEvent({
+    type: "control",
+    name: "done",
+    meta: { length: finalText.length, modelo },
+    timings,
+  });
+
+  const finalize = async () => finalized;
+  return {
+    raw: finalText,
+    modelo,
+    usage: undefined,
+    finalize,
+    timings,
+  };
+}

--- a/server/services/conversation/responseMetadata.ts
+++ b/server/services/conversation/responseMetadata.ts
@@ -1,0 +1,76 @@
+import type { GetEcoResult } from "../../utils";
+
+import type { EcoStreamMetaPayload } from "./types";
+
+export function buildFinalizedStreamText(result: GetEcoResult): string {
+  const intensidade = typeof result.intensidade === "number" ? result.intensidade : null;
+  const resumo = typeof result.resumo === "string" ? result.resumo : null;
+  const emocao = typeof result.emocao === "string" ? result.emocao : null;
+  const tags = Array.isArray(result.tags) ? result.tags : [];
+  const categoria = typeof result.categoria === "string" ? result.categoria : null;
+  const proactive = result.proactive ?? null;
+
+  const payload: Record<string, unknown> = {
+    intensidade,
+    resumo,
+    emocao,
+    tags,
+    categoria,
+    proactive,
+  };
+
+  const hasMeta =
+    intensidade !== null ||
+    (typeof resumo === "string" && resumo.trim() !== "") ||
+    (typeof emocao === "string" && emocao.trim() !== "") ||
+    (Array.isArray(tags) && tags.length > 0) ||
+    (typeof categoria === "string" && categoria.trim() !== "") ||
+    proactive !== null;
+
+  if (!hasMeta) {
+    return result.message ?? "";
+  }
+
+  return `${result.message ?? ""}` +
+    `\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
+}
+
+export function buildStreamingMetaPayload(
+  bloco: any,
+  cleanedFallback: string
+): EcoStreamMetaPayload | null {
+  if (!bloco || typeof bloco !== "object") {
+    return null;
+  }
+
+  const intensidade =
+    typeof bloco.intensidade === "number" && Number.isFinite(bloco.intensidade)
+      ? bloco.intensidade
+      : null;
+  const resumo = typeof bloco.analise_resumo === "string" ? bloco.analise_resumo.trim() : "";
+  const emocao = typeof bloco.emocao_principal === "string" ? bloco.emocao_principal.trim() : "";
+  const categoria = typeof bloco.categoria === "string" ? bloco.categoria.trim() : "";
+  const tags = Array.isArray(bloco.tags)
+    ? bloco.tags
+        .map((tag: any) => (typeof tag === "string" ? tag.trim() : ""))
+        .filter((tag: string) => tag.length > 0)
+    : [];
+
+  if (
+    intensidade === null ||
+    resumo.length === 0 ||
+    emocao.length === 0 ||
+    categoria.length === 0 ||
+    tags.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    intensidade,
+    resumo: resumo || cleanedFallback,
+    emocao,
+    categoria,
+    tags,
+  };
+}

--- a/server/services/conversation/streamingOrchestrator.ts
+++ b/server/services/conversation/streamingOrchestrator.ts
@@ -1,0 +1,343 @@
+import { streamClaudeChatCompletion, type Msg } from "../../core/ClaudeAdapter";
+import { log } from "../promptContext/logger";
+import { now } from "../../utils";
+
+import {
+  EcoStreamHandler,
+  EcoStreamingResult,
+  EcoLatencyMarks,
+  EcoStreamEvent,
+} from "./types";
+import { buildStreamingMetaPayload } from "./responseMetadata";
+import { salvarMemoriaViaRPC } from "./memoryPersistence";
+import { defaultResponseFinalizer, type PrecomputedFinalizeArtifacts } from "./responseFinalizer";
+
+import type { GetEcoResult } from "../../utils";
+
+const BLOCO_DEADLINE_MS = Number(process.env.ECO_BLOCO_DEADLINE_MS ?? 5000);
+const BLOCO_PENDING_MS = Number(process.env.ECO_BLOCO_PENDING_MS ?? 1000);
+
+interface StreamingExecutionParams {
+  prompt: Msg[];
+  maxTokens: number;
+  principalModel: string;
+  decision: { hasAssistantBefore: boolean };
+  ultimaMsg: string;
+  userName?: string | null;
+  userId: string;
+  supabase: any;
+  lastMessageId?: string;
+  sessionMeta?: any;
+  streamHandler: EcoStreamHandler;
+  timings: EcoLatencyMarks;
+}
+
+export async function executeStreamingLLM({
+  prompt,
+  maxTokens,
+  principalModel,
+  decision,
+  ultimaMsg,
+  userName,
+  userId,
+  supabase,
+  lastMessageId,
+  sessionMeta,
+  streamHandler,
+  timings,
+}: StreamingExecutionParams): Promise<EcoStreamingResult> {
+  const emitStream = async (event: EcoStreamEvent) => {
+    await streamHandler.onEvent(event);
+  };
+
+  const streamedChunks: string[] = [];
+  let chunkIndex = 0;
+  let firstTokenSent = false;
+  let usageFromStream: any;
+  let finishReason: string | null | undefined;
+  let modelFromStream: string | null | undefined;
+  let streamFailure: Error | null = null;
+
+  let resolveRawForBloco!: (value: string) => void;
+  let rejectRawForBloco!: (reason?: unknown) => void;
+  const rawForBlocoPromise = new Promise<string>((resolve, reject) => {
+    resolveRawForBloco = resolve;
+    rejectRawForBloco = reject;
+  });
+
+  type StreamingBlocoArtifacts = {
+    normalized: import("./responseFinalizer").NormalizedEcoResponse;
+    blocoPromise: Promise<any | null>;
+    blocoRacePromise: Promise<any | null>;
+  };
+
+  let blocoSetupPromise: Promise<StreamingBlocoArtifacts> | null = null;
+  let blocoPendingTimer: NodeJS.Timeout | null = null;
+  let blocoDeadlineTimer: NodeJS.Timeout | null = null;
+
+  const startBlocoPipeline = () => {
+    if (blocoSetupPromise) return;
+    blocoSetupPromise = (async () => {
+      try {
+        const rawForBloco = await rawForBlocoPromise;
+        const normalized = defaultResponseFinalizer.normalizeRawResponse({
+          raw: rawForBloco,
+          userName: userName ?? undefined,
+          hasAssistantBefore: decision.hasAssistantBefore,
+          mode: "full",
+        });
+
+        const blocoTimeout = defaultResponseFinalizer.gerarBlocoComTimeout({
+          ultimaMsg,
+          blocoTarget: normalized.blocoTarget,
+          mode: "full",
+          skipBloco: false,
+          distinctId: sessionMeta?.distinctId ?? userId,
+          userId,
+        });
+
+        const blocoPromise = blocoTimeout.full;
+        const blocoRacePromise = blocoTimeout.race;
+
+        let settled = false;
+        let deadlineExceeded = false;
+        const blocoStartedAt = now();
+
+        const clearPending = () => {
+          if (blocoPendingTimer) {
+            clearTimeout(blocoPendingTimer);
+            blocoPendingTimer = null;
+          }
+        };
+
+        const clearDeadline = () => {
+          if (blocoDeadlineTimer) {
+            clearTimeout(blocoDeadlineTimer);
+            blocoDeadlineTimer = null;
+          }
+        };
+
+        blocoPromise
+          .catch(() => undefined)
+          .finally(() => {
+            settled = true;
+            clearPending();
+            clearDeadline();
+          });
+
+        blocoPendingTimer = setTimeout(() => {
+          if (settled || deadlineExceeded) return;
+          log.info("[StreamingBloco] state=pending", {
+            pendingMs: BLOCO_PENDING_MS,
+            deadlineMs: BLOCO_DEADLINE_MS,
+          });
+          void emitStream({ type: "control", name: "meta_pending" });
+          blocoPendingTimer = null;
+        }, BLOCO_PENDING_MS);
+
+        blocoDeadlineTimer = setTimeout(() => {
+          if (settled) return;
+          deadlineExceeded = true;
+          clearPending();
+          log.warn("[StreamingBloco] state=deadline_exceeded", {
+            deadlineMs: BLOCO_DEADLINE_MS,
+          });
+          blocoDeadlineTimer = null;
+        }, BLOCO_DEADLINE_MS);
+
+        blocoRacePromise
+          .then(async (payload) => {
+            if (deadlineExceeded) return;
+
+            const durationMs = now() - blocoStartedAt;
+            if (!payload) {
+              log.info("[StreamingBloco] state=success", { durationMs, emitted: false });
+              return;
+            }
+
+            const metaPayload = buildStreamingMetaPayload(payload, normalized.cleaned);
+            if (!metaPayload) {
+              log.warn("[StreamingBloco] bloco payload inválido; meta não emitido", { durationMs });
+              return;
+            }
+
+            log.info("[StreamingBloco] state=success", { durationMs, emitted: true });
+            await emitStream({ type: "control", name: "meta", meta: metaPayload });
+
+            try {
+              const rpcRes = await salvarMemoriaViaRPC({
+                supabase,
+                userId,
+                mensagemId: lastMessageId ?? null,
+                meta: metaPayload,
+                origem: "streaming_bloco",
+              });
+
+              if (rpcRes.saved && rpcRes.memoriaId) {
+                await emitStream({
+                  type: "control",
+                  name: "memory_saved",
+                  meta: {
+                    memoriaId: rpcRes.memoriaId,
+                    primeiraMemoriaSignificativa: !!rpcRes.primeira,
+                    intensidade: metaPayload.intensidade,
+                  },
+                });
+              }
+            } catch (error: any) {
+              log.warn("[StreamingBloco] salvarMemoriaViaRPC falhou (ignorado)", {
+                message: error?.message,
+              });
+            }
+          })
+          .catch((error) => {
+            if (deadlineExceeded) return;
+            const message = error instanceof Error ? error.message : String(error);
+            log.warn("[StreamingBloco] bloco promise rejected", { message });
+          });
+
+        return { normalized, blocoPromise, blocoRacePromise };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log.warn("[StreamingBloco] failed to start bloco", { message });
+        throw error;
+      }
+    })();
+  };
+
+  timings.llmStart = now();
+  log.info("// LATENCY: llm_request_start", {
+    at: timings.llmStart,
+    sincePromptReadyMs:
+      timings.contextBuildEnd && timings.llmStart
+        ? timings.llmStart - timings.contextBuildEnd
+        : undefined,
+  });
+
+  const streamPromise = streamClaudeChatCompletion(
+    {
+      messages: prompt,
+      model: principalModel,
+      temperature: 0.6,
+      maxTokens,
+    },
+    {
+      async onChunk({ content }) {
+        if (!content) return;
+        streamedChunks.push(content);
+        if (!firstTokenSent) {
+          firstTokenSent = true;
+          await emitStream({ type: "control", name: "first_token" });
+        }
+        const currentIndex = chunkIndex;
+        chunkIndex += 1;
+        await emitStream({ type: "chunk", content, index: currentIndex });
+      },
+      async onControl(event) {
+        if (event.type === "reconnect") {
+          await emitStream({ type: "control", name: "reconnect", attempt: event.attempt });
+          return;
+        }
+        if (event.type === "done") {
+          usageFromStream = event.usage ?? usageFromStream;
+          finishReason = event.finishReason ?? finishReason;
+          modelFromStream = event.model ?? modelFromStream;
+        }
+      },
+      async onError(error) {
+        streamFailure = error;
+        rejectRawForBloco(error);
+        await emitStream({ type: "error", error });
+      },
+    }
+  ).catch((error: any) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    streamFailure = err;
+    rejectRawForBloco(err);
+    throw err;
+  });
+
+  startBlocoPipeline();
+
+  await emitStream({ type: "control", name: "prompt_ready", timings: { ...timings } });
+
+  try {
+    await streamPromise;
+  } finally {
+    timings.llmEnd = now();
+    log.info("// LATENCY: llm_request_end", {
+      at: timings.llmEnd,
+      durationMs:
+        timings.llmStart && timings.llmEnd ? timings.llmEnd - timings.llmStart : undefined,
+    });
+  }
+
+  if (streamFailure) {
+    throw streamFailure;
+  }
+
+  const raw = streamedChunks.join("");
+  resolveRawForBloco(raw);
+
+  let finalizePromise: Promise<GetEcoResult> | null = null;
+  const finalize = () => {
+    if (!finalizePromise) {
+      finalizePromise = (async () => {
+        let precomputed: PrecomputedFinalizeArtifacts | undefined;
+        if (blocoSetupPromise) {
+          try {
+            const artifacts = await blocoSetupPromise;
+            precomputed = {
+              normalized: artifacts.normalized,
+              blocoPromise: artifacts.blocoPromise,
+              blocoRacePromise: artifacts.blocoRacePromise,
+            };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            log.warn("[StreamingBloco] finalize ignoring precomputed bloco", { message });
+          }
+        }
+
+        return defaultResponseFinalizer.finalize({
+          raw,
+          ultimaMsg,
+          userName: userName ?? undefined,
+          hasAssistantBefore: decision.hasAssistantBefore,
+          userId,
+          supabase,
+          lastMessageId,
+          mode: "full",
+          startedAt: timings.llmStart ?? now(),
+          usageTokens: usageFromStream?.total_tokens ?? undefined,
+          modelo: modelFromStream ?? principalModel,
+          sessionMeta,
+          sessaoId: sessionMeta?.sessaoId ?? undefined,
+          origemSessao: sessionMeta?.origem ?? undefined,
+          precomputed,
+        });
+      })();
+    }
+    return finalizePromise;
+  };
+
+  const doneSnapshot = { ...timings };
+  await emitStream({
+    type: "control",
+    name: "done",
+    meta: {
+      finishReason,
+      usage: usageFromStream,
+      modelo: modelFromStream ?? principalModel,
+      length: raw.length,
+    },
+    timings: doneSnapshot,
+  });
+
+  return {
+    raw,
+    modelo: modelFromStream ?? principalModel,
+    usage: usageFromStream,
+    finalize,
+    timings: doneSnapshot,
+  };
+}

--- a/server/services/conversation/types.ts
+++ b/server/services/conversation/types.ts
@@ -1,0 +1,63 @@
+import type { ORUsage } from "../../core/ClaudeAdapter";
+import type { GetEcoResult } from "../../utils";
+
+export interface EcoLatencyMarks {
+  contextBuildStart?: number;
+  contextBuildEnd?: number;
+  llmStart?: number;
+  llmEnd?: number;
+}
+
+export type EcoStreamEvent =
+  | {
+      type: "control";
+      name: "prompt_ready" | "first_token" | "reconnect";
+      attempt?: number;
+      timings?: EcoLatencyMarks;
+    }
+  | {
+      type: "control";
+      name: "done";
+      meta?: { finishReason?: string | null; usage?: ORUsage; modelo?: string | null; length?: number };
+      timings?: EcoLatencyMarks;
+    }
+  | {
+      type: "control";
+      name: "meta_pending";
+    }
+  | {
+      type: "control";
+      name: "meta";
+      meta: EcoStreamMetaPayload;
+    }
+  | {
+      type: "control";
+      name: "memory_saved";
+      meta: {
+        memoriaId: string;
+        primeiraMemoriaSignificativa: boolean;
+        intensidade: number;
+      };
+    }
+  | { type: "chunk"; content: string; index: number }
+  | { type: "error"; error: Error };
+
+export interface EcoStreamHandler {
+  onEvent: (event: EcoStreamEvent) => void | Promise<void>;
+}
+
+export interface EcoStreamingResult {
+  raw: string;
+  modelo?: string | null;
+  usage?: ORUsage;
+  finalize: () => Promise<GetEcoResult>;
+  timings: EcoLatencyMarks;
+}
+
+export interface EcoStreamMetaPayload {
+  intensidade: number;
+  resumo: string;
+  emocao: string;
+  categoria: string;
+  tags: string[];
+}


### PR DESCRIPTION
## Summary
- split response metadata helpers, memory persistence, and shared types into dedicated modules
- extract pre-LLM shortcut handling, context preparation, and LLM execution flows into focused services
- simplify ConversationOrchestrator to compose new modules and update routes to consume moved exports

## Testing
- npm run build --prefix server

------
https://chatgpt.com/codex/tasks/task_e_68e30f70db888325ab1793b8e5c33e53