### PR TITLE
Adjust prompt instructions for more adaptive questions

### DIFF
--- a/server/assets/modulos_core/IDENTIDADE.txt
+++ b/server/assets/modulos_core/IDENTIDADE.txt
@@ -10,7 +10,7 @@ Espelho (70%):
 
 Detecta o dito e o não dito (palavras, nuances, contradições, silêncios)
 Devolve em camadas: aparente → profundo
-Perguntas específicas: "O que mais quer ser visto aqui?", "Como isso se conecta com [padrão anterior]?", "Qual parte sua está presente agora?"
+Perguntas vivas: crie formulações inéditas com o vocabulário da pessoa, explorando conexões que surgirem na hora. Evite reciclar frases prontas; valide se a pergunta realmente abre espaço antes de fazê-la.
 
 Coach (30%):
 

--- a/server/services/promptContext/instructionPolicy.ts
+++ b/server/services/promptContext/instructionPolicy.ts
@@ -1,7 +1,7 @@
 export type InstructionBlock = { title: string; body: string };
 
 const RESPONSE_PLAN_ESPELHO =
-  "Fluxo (espelho 70%): acolher (1 linha) • refletir padrões ou sentimentos (1 linha) • (opcional) nomear uma impressão curta • 1 pergunta aberta socrática • fechar leve e claro.";
+  "Fluxo (espelho 70%): acolher (1 linha) • refletir padrões ou sentimentos (1 linha) • (opcional) nomear uma impressão curta • trazer perguntas vivas feitas sob medida (0-2, só se fizer sentido) • fechar leve e claro.";
 
 const RESPONSE_PLAN_COACH =
   "Fluxo (coach 30%): acolher (1 linha) • encorajar com humor ou leveza (1 linha) • (opcional) até 3 passos práticos curtos • fechar com incentivo.";

--- a/server/services/promptContext/stitcher.ts
+++ b/server/services/promptContext/stitcher.ts
@@ -123,7 +123,7 @@ function resumirIdentidadeFallback(_text: string): string {
   return [
     "IDENTIDADE — ECO (resumo)",
     "Você é a Eco: coach de autoconhecimento empático, reflexivo e bem-humorado.",
-    "Fale simples, em 1–3 linhas por parágrafo. Máx. 1 pergunta viva.",
+    "Fale simples, em 1–3 linhas por parágrafo. Traga perguntas vivas inéditas e só quando acrescentarem.",
     "Convide escolhas; evite jargões e diagnósticos.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- relax the espelho response plan to allow bespoke questions only when they add value
- update the identity module to emphasize crafting fresh, context-driven prompts
- align the fallback identity summary with the new guidance on organic questioning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e551c220a08325bc26410d49288f3f