### PR TITLE
Add emotion-aware fallback planner for fast lane responses

### DIFF
--- a/server/core/ResponseGenerator.ts
+++ b/server/core/ResponseGenerator.ts
@@ -1,6 +1,7 @@
 import { callOpenRouterChat } from "../adapters/OpenRouterAdapter";
 import { limparResposta, formatarTextoEco } from "../utils/text";
 import { hedge } from "./policies/hedge";
+import { REFLEXO_PATTERNS } from "./reflexoPatterns";
 
 const MODEL_MAIN     = process.env.ECO_MODEL_MAIN     || "openai/gpt-5-chat";
 const MODEL_TECH_ALT = process.env.ECO_MODEL_TECH_ALT || "openai/gpt-5-mini";
@@ -37,147 +38,6 @@ export async function fastGreet(prompt: string) {
  * microReflexoLocal (expandido)
  * --------------------------- */
 
-type ReflexaoPattern = {
-  patterns: RegExp[];
-  responses: string[];
-  /** quanto MENOR, mais prioritário (1 > 2 > 3) */
-  priority: 1 | 2 | 3;
-};
-
-const REFLEXAO_MAP: Record<string, ReflexaoPattern> = {
-  // Energia baixa / Exaustão
-  cansaco: {
-    patterns: [/cansad/, /exaust/, /esgotad/, /sem energia/, /sem forç/, /derrubad/],
-    responses: [
-      "Entendi. Parece que o corpo está pedindo pausa. Quer começar com 1 minuto de respiração ou prefere só desabafar um pouco?",
-      "O cansaço chegou forte. Topa fazer um check-in rápido: qual parte do corpo grita mais por descanso?",
-      "Percebo a sua exaustão. Antes de mais nada: quando foi a última pausa real? Quer começar com água e 3 respirações profundas?"
-    ],
-    priority: 2
-  },
-
-  // Ansiedade / Preocupação
-  ansiedade: {
-    patterns: [/ansios/, /preocupad/, /nervos/, /agitad/, /inquiet/, /tens[aã]o/, /estress/],
-    responses: [
-      "Percebo ansiedade aí. Topa notar 3 pontos de apoio do corpo agora e, se quiser, me contar onde ela pega mais?",
-      "A ansiedade está alta. Vamos tentar: nome 5 coisas que você vê, 4 que você toca, 3 que você ouve. Ou prefere falar primeiro?",
-      "Sinto a tensão. Quer soltar em palavras o que mais preocupa, ou começamos baixando a ativação do corpo?"
-    ],
-    priority: 1
-  },
-
-  // Tristeza / Melancolia
-  tristeza: {
-    patterns: [/triste/, /melancoli/, /deprimi/, /pra baixo/, /down/, /desanimat/, /vazi/],
-    responses: [
-      "Sinto a tristeza chegando. Prefere nomear o que mais doeu ou que eu guie uma micro-pausa?",
-      "A tristeza pede espaço. Topa dar nome ao que tá pesando e depois a gente vê o que fazer com isso?",
-      "Percebo o peso. Quer escrever livremente sobre o que tá sentindo ou prefere uma presença quieta por um minuto?"
-    ],
-    priority: 2
-  },
-
-  // Raiva / Irritação
-  raiva: {
-    patterns: [/irritad/, /raiva/, /bravo/, /puto/, /com raiva/, /ódio/, /furioso/],
-    responses: [
-      "Raiva é energia. Quer soltar em palavras o gatilho principal, sem filtro, ou tentamos baixar um pouco a ativação primeiro?",
-      "Sinto a irritação. Topa nomear: o que foi a gota d'água? E o que você gostaria de fazer com essa energia?",
-      "A raiva tem mensagem. Quer descarregar aqui primeiro ou já mapear o que ela tá protegendo?"
-    ],
-    priority: 1
-  },
-
-  // Medo / Insegurança
-  medo: {
-    patterns: [/medo/, /receio/, /insegur/, /apreensiv/, /assustado/, /com medo/, /pânico/],
-    responses: [
-      "Tem medo no ar. Podemos mapear rapidamente: 1) o que ameaça, 2) o que te protege, 3) qual seria o próximo passo menor. Topa?",
-      "O medo apareceu. Primeiro: você está seguro agora? Depois a gente nomeia do que é o medo e o que fazer com ele.",
-      "Percebo a insegurança. Quer identificar se é medo real ou ansiedade do 'e se'? Te ajudo a separar os dois."
-    ],
-    priority: 1
-  },
-
-  // Sobrecarga / Overwhelm
-  sobrecarga: {
-    patterns: [/sobrecarregad/, /muito/, /demais/, /n[aã]o aguento/, /não dou conta/, /overwhelm/],
-    responses: [
-      "Sobrecarga detectada. Vamos fazer um 'dump cerebral'? Lista tudo sem ordem, depois a gente organiza o que é urgente de verdade.",
-      "Parece que tá sendo demais. Topa fazer um inventário: 1) o que é urgente real, 2) o que é só barulho, 3) o que pode esperar?",
-      "Entendo. Muita coisa junto. Quer começar escolhendo UMA coisa pra resolver agora, ou precisa desabafar tudo primeiro?"
-    ],
-    priority: 1
-  },
-
-  // Confusão / Indecisão
-  confusao: {
-    patterns: [/confus/, /perdid/, /sem rumo/, /não sei/, /indecis/, /bagunçad/],
-    responses: [
-      "Percebo a confusão. Vamos clarear: qual a pergunta principal que tá presa aí? Às vezes só nomear já ajuda.",
-      "Tá nebuloso. Topa fazer um exercício? Completa: 'Eu estaria mais claro se...' e vê o que vem.",
-      "A indecisão tem espaço. Quer listar prós/contras ou prefere explorar o que você realmente quer por baixo disso?"
-    ],
-    priority: 2
-  },
-
-  // Solidão / Desconexão
-  solidao: {
-    patterns: [/solitári/, /sozinho/, /isolad/, /desconect/, /distante/, /abandonad/],
-    responses: [
-      "Sinto a solidão. Ela é física (falta de gente) ou emocional (mesmo perto de outros)? Isso muda o caminho.",
-      "A desconexão pesa. Topa identificar: com quem/o quê você sente falta de conexão? Pessoas, você mesmo, propósito?",
-      "Percebo o isolamento. Quer começar reconectando com você mesmo aqui (eu te acompanho) ou prefere pensar em pontes pra fora?"
-    ],
-    priority: 2
-  },
-
-  // Culpa / Vergonha
-  culpa: {
-    patterns: [/culpad/, /vergonha/, /arrependid/, /remorso/, /erro meu/],
-    responses: [
-      "Tem culpa no ar. Vamos separar: foi erro seu mesmo ou você tá carregando peso que não é seu? Faz diferença.",
-      "A culpa apareceu. Topa um exercício? 1) O que aconteceu (fatos), 2) O que você podia controlar de verdade, 3) O que fazer agora.",
-      "Percebo vergonha. Ela costuma distorcer. Quer nomear o que aconteceu sem julgamento, tipo contando pra um amigo?"
-    ],
-    priority: 2
-  },
-
-  // Frustração / Bloqueio
-  frustracao: {
-    patterns: [/frustrad/, /travad/, /bloquead/, /empacad/, /não sai/, /não anda/],
-    responses: [
-      "Frustração detectada. O que tá travando: falta de clareza, falta de energia ou obstáculo real? Vamos destrinchar.",
-      "Percebo o bloqueio. Às vezes ajuda trocar: ao invés de 'por que não consigo?', tenta 'o que eu precisaria pra conseguir?'.",
-      "Tá empacado. Topa mudar o ângulo? Me conta: se isso não importasse nada, o que você faria diferente?"
-    ],
-    priority: 2
-  },
-
-  // Esperança / Motivação baixa
-  desmotivacao: {
-    patterns: [/desmotivad/, /sem esperança/, /desistindo/, /não vale/, /pra qu[eê]/, /tanto faz/],
-    responses: [
-      "Percebo a desmotivação. Ela é cansaço (precisa pausa) ou descrença (precisa reconectar com o porquê)? São caminhos diferentes.",
-      "A esperança tá baixa. Topa fazer um resgate? Lembra de uma vez que você superou algo difícil - o que te moveu lá?",
-      "Sinto o 'pra quê'. Sem pressão: se você tivesse só 10% de energia, no que você investiria? Às vezes o menor passo acorda algo."
-    ],
-    priority: 2
-  },
-
-  // Gratidão / Positivo (também vale reconhecer!)
-  gratidao: {
-    patterns: [/grat/, /feliz/, /alegre/, /bem/, /ótimo/, /maravilh/, /aliviado/],
-    responses: [
-      "Que bom sentir isso! Topa registrar o que está gerando esse bem-estar? Anotar ajuda a voltar aqui quando precisar.",
-      "Percebo leveza. Aproveita: o que desse momento você quer guardar ou expandir?",
-      "Legal! Quer celebrar isso de alguma forma ou só deixar a sensação acontecer?"
-    ],
-    priority: 3
-  }
-};
-
 function pickRandom<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
@@ -188,9 +48,9 @@ export function microReflexoLocal(msg: string): string | null {
 
   const hits: { key: string; priority: number; responses: string[] }[] = [];
 
-  for (const [key, cfg] of Object.entries(REFLEXAO_MAP)) {
+  for (const [key, cfg] of Object.entries(REFLEXO_PATTERNS)) {
     if (cfg.patterns.some((rx) => rx.test(t))) {
-      hits.push({ key, priority: cfg.priority, responses: cfg.responses });
+      hits.push({ key, priority: cfg.priority, responses: cfg.microResponses });
     }
   }
 
@@ -199,6 +59,7 @@ export function microReflexoLocal(msg: string): string | null {
   // menor prioridade = mais urgente (1 > 2 > 3)
   hits.sort((a, b) => a.priority - b.priority);
   const best = hits[0];
+  if (!best.responses.length) return null;
   return pickRandom(best.responses) ?? null;
 }
 

--- a/server/core/ResponsePlanner.ts
+++ b/server/core/ResponsePlanner.ts
@@ -1,0 +1,52 @@
+import { REFLEXO_PATTERNS, type ReflexaoPlanner } from "./reflexoPatterns";
+
+export type ResponsePlan = {
+  theme?: string;
+  priority: number;
+  acknowledgement: string;
+  exploration: string;
+  invitation: string;
+};
+
+const DEFAULT_PLANNER: ReflexaoPlanner = {
+  acknowledgement: "Estou aqui, presente com você.",
+  exploration: "Vamos respirar um instante e notar o que este momento desperta em pensamentos, corpo ou emoções.",
+  invitation: "Qual parte disso pede mais atenção agora para ganharmos clareza?",
+};
+
+function normalize(text: string): string {
+  return (text || "").trim().toLowerCase();
+}
+
+export function planCuriousFallback(message: string): { text: string; plan: ResponsePlan } {
+  const normalized = normalize(message);
+  const hits: {
+    key: string;
+    priority: number;
+    planner: ReflexaoPlanner;
+  }[] = [];
+
+  for (const [key, entry] of Object.entries(REFLEXO_PATTERNS)) {
+    if (entry.patterns.some((rx) => rx.test(normalized))) {
+      hits.push({ key, priority: entry.priority, planner: entry.planner });
+    }
+  }
+
+  hits.sort((a, b) => a.priority - b.priority);
+  const selected = hits[0];
+
+  const basePlanner = selected?.planner ?? DEFAULT_PLANNER;
+  const plan: ResponsePlan = {
+    theme: selected?.key,
+    priority: selected?.priority ?? 4,
+    acknowledgement: basePlanner.acknowledgement,
+    exploration: basePlanner.exploration,
+    invitation: basePlanner.invitation,
+  };
+
+  const text = [plan.acknowledgement, plan.exploration, plan.invitation]
+    .filter(Boolean)
+    .join(" ");
+
+  return { text, plan };
+}

--- a/server/core/reflexoPatterns.ts
+++ b/server/core/reflexoPatterns.ts
@@ -1,0 +1,208 @@
+export type ReflexaoPlanner = {
+  acknowledgement: string;
+  exploration: string;
+  invitation: string;
+};
+
+export type ReflexaoPattern = {
+  patterns: RegExp[];
+  priority: 1 | 2 | 3;
+  microResponses: string[];
+  planner: ReflexaoPlanner;
+};
+
+export const REFLEXO_PATTERNS: Record<string, ReflexaoPattern> = {
+  // Energia baixa / Exaustão
+  cansaco: {
+    patterns: [/cansad/, /exaust/, /esgotad/, /sem energia/, /sem forç/, /derrubad/],
+    priority: 2,
+    microResponses: [
+      "Entendi. Parece que o corpo está pedindo pausa. Quer começar com 1 minuto de respiração ou prefere só desabafar um pouco?",
+      "O cansaço chegou forte. Topa fazer um check-in rápido: qual parte do corpo grita mais por descanso?",
+      "Percebo a sua exaustão. Antes de mais nada: quando foi a última pausa real? Quer começar com água e 3 respirações profundas?",
+    ],
+    planner: {
+      acknowledgement: "Percebo o peso do cansaço no que você traz.",
+      exploration: "Vamos notar onde esse desgaste aparece — no corpo, na mente ou nas emoções?",
+      invitation: "O que seria um primeiro gesto de cuidado para você agora, mesmo que pequeno?",
+    },
+  },
+
+  // Ansiedade / Preocupação
+  ansiedade: {
+    patterns: [/ansios/, /preocupad/, /nervos/, /agitad/, /inquiet/, /tens[aã]o/, /estress/],
+    priority: 1,
+    microResponses: [
+      "Percebo ansiedade aí. Topa notar 3 pontos de apoio do corpo agora e, se quiser, me contar onde ela pega mais?",
+      "A ansiedade está alta. Vamos tentar: nome 5 coisas que você vê, 4 que você toca, 3 que você ouve. Ou prefere falar primeiro?",
+      "Sinto a tensão. Quer soltar em palavras o que mais preocupa, ou começamos baixando a ativação do corpo?",
+    ],
+    planner: {
+      acknowledgement: "Percebo um fio de ansiedade no que você descreve.",
+      exploration: "Que tal observar por um instante como ela se manifesta — na respiração, nos pensamentos ou no corpo?",
+      invitation: "Se essa ansiedade pudesse falar, o que ela gostaria que você soubesse agora?",
+    },
+  },
+
+  // Tristeza / Melancolia
+  tristeza: {
+    patterns: [/triste/, /melancoli/, /deprimi/, /pra baixo/, /down/, /desanimat/, /vazi/],
+    priority: 2,
+    microResponses: [
+      "Sinto a tristeza chegando. Prefere nomear o que mais doeu ou que eu guie uma micro-pausa?",
+      "A tristeza pede espaço. Topa dar nome ao que tá pesando e depois a gente vê o que fazer com isso?",
+      "Percebo o peso. Quer escrever livremente sobre o que tá sentindo ou prefere uma presença quieta por um minuto?",
+    ],
+    planner: {
+      acknowledgement: "Sinto a presença de tristeza nas suas palavras.",
+      exploration: "Vamos olhar com cuidado para o que ela quer mostrar — há um fato, uma falta, uma memória pedindo atenção?",
+      invitation: "O que essa tristeza revela sobre o que é importante para você neste momento?",
+    },
+  },
+
+  // Raiva / Irritação
+  raiva: {
+    patterns: [/irritad/, /raiva/, /bravo/, /puto/, /com raiva/, /ódio/, /furioso/],
+    priority: 1,
+    microResponses: [
+      "Raiva é energia. Quer soltar em palavras o gatilho principal, sem filtro, ou tentamos baixar um pouco a ativação primeiro?",
+      "Sinto a irritação. Topa nomear: o que foi a gota d'água? E o que você gostaria de fazer com essa energia?",
+      "A raiva tem mensagem. Quer descarregar aqui primeiro ou já mapear o que ela tá protegendo?",
+    ],
+    planner: {
+      acknowledgement: "Reconheço a faísca de raiva que apareceu por aqui.",
+      exploration: "Vamos identificar o que foi tocado em você — limite, injustiça, expectativa quebrada?",
+      invitation: "Se essa raiva estivesse defendendo algo precioso, o que seria?",
+    },
+  },
+
+  // Medo / Insegurança
+  medo: {
+    patterns: [/medo/, /receio/, /insegur/, /apreensiv/, /assustado/, /com medo/, /pânico/],
+    priority: 1,
+    microResponses: [
+      "Tem medo no ar. Podemos mapear rapidamente: 1) o que ameaça, 2) o que te protege, 3) qual seria o próximo passo menor. Topa?",
+      "O medo apareceu. Primeiro: você está seguro agora? Depois a gente nomeia do que é o medo e o que fazer com ele.",
+      "Percebo a insegurança. Quer identificar se é medo real ou ansiedade do 'e se'? Te ajudo a separar os dois.",
+    ],
+    planner: {
+      acknowledgement: "Percebo medo ou insegurança pulsando no que você disse.",
+      exploration: "Vamos checar juntos: há um risco real agora ou principalmente cenários imaginados?",
+      invitation: "O que ajudaria você a se sentir um pouco mais seguro para olhar para isso com clareza?",
+    },
+  },
+
+  // Sobrecarga / Overwhelm
+  sobrecarga: {
+    patterns: [/sobrecarregad/, /muito/, /demais/, /n[aã]o aguento/, /não dou conta/, /overwhelm/],
+    priority: 1,
+    microResponses: [
+      "Sobrecarga detectada. Vamos fazer um 'dump cerebral'? Lista tudo sem ordem, depois a gente organiza o que é urgente de verdade.",
+      "Parece que tá sendo demais. Topa fazer um inventário: 1) o que é urgente real, 2) o que é só barulho, 3) o que pode esperar?",
+      "Entendo. Muita coisa junto. Quer começar escolhendo UMA coisa pra resolver agora, ou precisa desabafar tudo primeiro?",
+    ],
+    planner: {
+      acknowledgement: "Soa como se estivesse tudo pesado demais ao mesmo tempo.",
+      exploration: "Vamos mapear o território: o que é urgente real, o que é barulho e o que pode esperar um pouco?",
+      invitation: "Qual pequeno passo faria diferença para aliviar 5% desse acúmulo agora?",
+    },
+  },
+
+  // Confusão / Indecisão
+  confusao: {
+    patterns: [/confus/, /perdid/, /sem rumo/, /não sei/, /indecis/, /bagunçad/],
+    priority: 2,
+    microResponses: [
+      "Percebo a confusão. Vamos clarear: qual a pergunta principal que tá presa aí? Às vezes só nomear já ajuda.",
+      "Tá nebuloso. Topa fazer um exercício? Completa: 'Eu estaria mais claro se...' e vê o que vem.",
+      "A indecisão tem espaço. Quer listar prós/contras ou prefere explorar o que você realmente quer por baixo disso?",
+    ],
+    planner: {
+      acknowledgement: "Ouço bastante névoa aí dentro, como se nada encaixasse direito.",
+      exploration: "Vamos separar o que é fato, suposição e desejo pra ver onde a clareza pode surgir?",
+      invitation: "Qual pergunta merece ser respondida primeiro para você se orientar melhor?",
+    },
+  },
+
+  // Solidão / Desconexão
+  solidao: {
+    patterns: [/solitári/, /sozinho/, /isolad/, /desconect/, /distante/, /abandonad/],
+    priority: 2,
+    microResponses: [
+      "Sinto a solidão. Ela é física (falta de gente) ou emocional (mesmo perto de outros)? Isso muda o caminho.",
+      "A desconexão pesa. Topa identificar: com quem/o quê você sente falta de conexão? Pessoas, você mesmo, propósito?",
+      "Percebo o isolamento. Quer começar reconectando com você mesmo aqui (eu te acompanho) ou prefere pensar em pontes pra fora?",
+    ],
+    planner: {
+      acknowledgement: "Reconheço uma sensação de solidão ou desconexão no que você traz.",
+      exploration: "Vamos explorar se é falta de presença externa, de vínculo interno ou das duas coisas?",
+      invitation: "Que tipo de conexão seu coração está pedindo agora — consigo mesmo, com alguém ou com um sentido maior?",
+    },
+  },
+
+  // Culpa / Vergonha
+  culpa: {
+    patterns: [/culpad/, /vergonha/, /arrependid/, /remorso/, /erro meu/],
+    priority: 2,
+    microResponses: [
+      "Tem culpa no ar. Vamos separar: foi erro seu mesmo ou você tá carregando peso que não é seu? Faz diferença.",
+      "A culpa apareceu. Topa um exercício? 1) O que aconteceu (fatos), 2) O que você podia controlar de verdade, 3) O que fazer agora.",
+      "Percebo vergonha. Ela costuma distorcer. Quer nomear o que aconteceu sem julgamento, tipo contando pra um amigo?",
+    ],
+    planner: {
+      acknowledgement: "Sinto um gosto de culpa ou vergonha nas suas palavras.",
+      exploration: "Vamos separar fatos de interpretações pra entender o que realmente foi sua responsabilidade?",
+      invitation: "O que você precisa reconhecer ou reparar para seguir com mais gentileza consigo mesmo?",
+    },
+  },
+
+  // Frustração / Bloqueio
+  frustracao: {
+    patterns: [/frustrad/, /travad/, /bloquead/, /empacad/, /não sai/, /não anda/],
+    priority: 2,
+    microResponses: [
+      "Frustração detectada. O que tá travando: falta de clareza, falta de energia ou obstáculo real? Vamos destrinchar.",
+      "Percebo o bloqueio. Às vezes ajuda trocar: ao invés de 'por que não consigo?', tenta 'o que eu precisaria pra conseguir?'.",
+      "Tá empacado. Topa mudar o ângulo? Me conta: se isso não importasse nada, o que você faria diferente?",
+    ],
+    planner: {
+      acknowledgement: "Vejo uma trava aí, misto de frustração com vontade de avançar.",
+      exploration: "Vamos investigar se o bloqueio é falta de clareza, energia ou um obstáculo concreto?",
+      invitation: "O que liberaria um pequeno movimento agora — apoio, descanso, nova estratégia?",
+    },
+  },
+
+  // Esperança / Motivação baixa
+  desmotivacao: {
+    patterns: [/desmotivad/, /sem esperança/, /desistindo/, /não vale/, /pra qu[eê]/, /tanto faz/],
+    priority: 2,
+    microResponses: [
+      "Percebo a desmotivação. Ela é cansaço (precisa pausa) ou descrença (precisa reconectar com o porquê)? São caminhos diferentes.",
+      "A esperança tá baixa. Topa fazer um resgate? Lembra de uma vez que você superou algo difícil - o que te moveu lá?",
+      "Sinto o 'pra quê'. Sem pressão: se você tivesse só 10% de energia, no que você investiria? Às vezes o menor passo acorda algo.",
+    ],
+    planner: {
+      acknowledgement: "Percebo a motivação baixinha, quase sem faísca.",
+      exploration: "Vamos distinguir se é falta de energia, de sentido ou de resultados visíveis?",
+      invitation: "Qual seria um gesto minúsculo que honraria o que importa pra você, mesmo com pouca energia?",
+    },
+  },
+
+  // Gratidão / Positivo
+  gratidao: {
+    patterns: [/grat/, /feliz/, /alegre/, /bem/, /ótimo/, /maravilh/, /aliviado/],
+    priority: 3,
+    microResponses: [
+      "Que bom sentir isso! Topa registrar o que está gerando esse bem-estar? Anotar ajuda a voltar aqui quando precisar.",
+      "Percebo leveza. Aproveita: o que desse momento você quer guardar ou expandir?",
+      "Legal! Quer celebrar isso de alguma forma ou só deixar a sensação acontecer?",
+    ],
+    planner: {
+      acknowledgement: "É bonito sentir a leveza e gratidão que você compartilha.",
+      exploration: "Vamos nomear o que exatamente desperta essa sensação para poder revisitá-la depois?",
+      invitation: "Como você pode honrar ou expandir esse bem-estar de um jeito simples hoje?",
+    },
+  },
+};
+
+export type ReflexaoKey = keyof typeof REFLEXO_PATTERNS;

--- a/server/services/conversation/fastLane.ts
+++ b/server/services/conversation/fastLane.ts
@@ -5,6 +5,7 @@ import {
   type SessionMetadata,
 } from "../../utils";
 import { log } from "../promptContext/logger";
+import { planCuriousFallback } from "../../core/ResponsePlanner";
 import type { FinalizeParams } from "./responseFinalizer";
 
 type ClaudeMessage = { role: "system" | "user" | "assistant"; content: string };
@@ -128,7 +129,7 @@ export async function runFastLaneLLM({
     completion = await deps.claudeClient(payload);
   } catch (error: any) {
     log.warn(`[fastLaneLLM] falhou: ${error?.message}`);
-    const fallback = "Tô aqui com você. Quer me contar um pouco mais?";
+    const { text: fallback } = planCuriousFallback(ultimaMsg);
     const response = await deps.responseFinalizer.finalize({
       raw: fallback,
       ultimaMsg,

--- a/server/tests/conversation/fastLane.test.ts
+++ b/server/tests/conversation/fastLane.test.ts
@@ -6,6 +6,7 @@ import {
   runFastLaneLLM,
   type RunFastLaneLLMResult,
 } from "../../services/conversation/fastLane";
+import { planCuriousFallback } from "../../core/ResponsePlanner";
 
 function createDeps(overrides: Partial<{
   claudeClient: any;
@@ -105,6 +106,7 @@ test("runFastLaneLLM envia apenas as 3 últimas mensagens do histórico", async 
 test("runFastLaneLLM usa fallback quando o cliente Claude falha", async () => {
   const fallbackError = new Error("claude indisponível");
   const fallbackCalls: any[] = [];
+  const expectedFallback = planCuriousFallback("oi").text;
 
   const { deps } = createDeps({
     claudeClient: async () => {
@@ -131,11 +133,11 @@ test("runFastLaneLLM usa fallback quando o cliente Claude falha", async () => {
     sessionMeta: { distinctId: "fallback-1" },
   });
 
-  assert.strictEqual(result.raw, "Tô aqui com você. Quer me contar um pouco mais?");
+  assert.strictEqual(result.raw, expectedFallback);
   assert.strictEqual(result.model, "fastlane-fallback");
   assert.strictEqual(result.usage, null);
   assert.deepStrictEqual(result.response, {
-    message: "Tô aqui com você. Quer me contar um pouco mais?",
+    message: expectedFallback,
   });
   assert.strictEqual(fallbackCalls.length, 1);
   assert.strictEqual(

--- a/server/tests/core/ResponsePlanner.test.ts
+++ b/server/tests/core/ResponsePlanner.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { planCuriousFallback } from "../../core/ResponsePlanner";
+
+test("planCuriousFallback cria plano temático quando há pistas emocionais", () => {
+  const { text, plan } = planCuriousFallback("estou muito ansiosa com tudo");
+
+  assert.ok(text.includes("ansiedade"), "texto menciona ansiedade");
+  assert.strictEqual(plan.theme, "ansiedade");
+  assert.ok(plan.acknowledgement.length > 0);
+  assert.ok(plan.exploration.length > 0);
+  assert.ok(plan.invitation.length > 0);
+});
+
+test("planCuriousFallback usa plano padrão quando não encontra tema", () => {
+  const { text, plan } = planCuriousFallback("oi");
+
+  assert.strictEqual(plan.theme, undefined);
+  assert.strictEqual(plan.priority, 4);
+  assert.ok(text.includes("Estou aqui, presente"));
+});


### PR DESCRIPTION
## Summary
- extract shared reflexo pattern catalog with planner prompts for each emotional theme
- add a response planner that crafts curiosity-oriented fallback text and plug it into the fast lane fallback path
- update conversation and planner tests to cover the new planner output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5626e31a88325944846c1449dc6a0